### PR TITLE
Affiliate Window Fixes

### DIFF
--- a/Oara/Network/Publisher/AdCell.php
+++ b/Oara/Network/Publisher/AdCell.php
@@ -1,0 +1,253 @@
+<?php
+namespace Oara\Network\Publisher;
+use Oara\Utilities;
+
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+
+class AdCell extends \Oara\Network
+{
+	private $_user_id = null;
+	private $_api_password = null;
+	private $_token = null;
+	/**
+	 * API URL
+	 * @var string
+	 */
+	protected $_apiUrl = 'https://www.adcell.de/api/';
+	/**
+	 * API version
+	 * @var string
+	 */
+	protected $_apiVersion = 'v2';
+
+
+
+	/**
+	 * @param $credentials
+	 * @throws Exception
+	 */
+	public function login($credentials)
+	{
+		/**
+		 * https://www.adcell.de/api/v2/user/getToken?userName=[userName]&password=[apiPassword]
+		 */
+		$this->_user_id = $credentials['user'];
+		$this->_api_password = $credentials['password'];
+
+		$this->getToken();
+	}
+
+
+	public function getToken() {
+		if (!empty($this->_token)) {
+			return $this->_token;
+		}
+
+		$data = $this->_request(
+			'user',
+			'getToken',
+			array(
+				'userName' => $this->_user_id,
+				'password' => $this->_api_password,
+			)
+		);
+
+		if ($data && isset($data['data']['token'])) {
+			$this->_token = $data['data']['token']; // Expires in 15 minutes
+		}
+		return $this->_token;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
+
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
+
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials[] = $parameter;
+
+		return $credentials;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = true;
+		return $connection;
+	}
+
+
+
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		/**
+		 * https://www.adcell.de/api/v2/?language=en#&controller=Affiliate_Statistic&apiCall=affiliate_statistic_byCommission
+		 */
+		$totalTransactions = array();
+		try{
+			$start_date = $dStartDate->format('Y-m-d');
+			$end_date = $dEndDate->format('Y-m-d');
+			$page = 1;
+			$loop = true;
+
+			while ($loop){
+
+				$transactionsList = $this->_request(
+					'affiliate',
+					'statistic/byCommission',
+					array(
+						'token' => $this->getToken(),
+						'startDate' => $start_date, //Format YYYY-mm-dd
+						'endDate' => $end_date, //Format YYYY-mm-dd
+						'page' => $page, //limit 25 rows
+					)
+				);
+
+				if (isset($transactionsList['data']['items'])){
+					if (count($transactionsList['data']['items']) == 0) {
+						$loop = false;
+						break;
+					}
+					foreach ($transactionsList['data']['items'] as $transaction) {
+						$a_transaction['unique_id'] = $transaction['commissionId'];
+						$a_transaction['date'] = $transaction['createTime'];
+						$a_transaction['update_date'] = $transaction['changeTime'];
+						$a_transaction['change_note'] = $transaction['changeNote'];
+						$a_transaction['IP'] = $transaction['ip'];
+						$a_transaction['merchantId'] = $transaction['programId'];
+						$a_transaction['merchantName'] = $transaction['programName'];
+						$a_transaction['campaign_name'] = $transaction['eventName'];
+						$a_transaction['custom_id'] = $transaction['subId'];
+						$a_transaction['amount'] = Utilities::parseDouble($transaction['totalShoppingCart']);
+						$a_transaction['commission'] = Utilities::parseDouble($transaction['totalCommission']);
+						$a_transaction['referrer'] = $transaction['referer'];
+						switch ($transaction['status']){
+							/*
+							 * open = open commission
+							 * cancelled = cancelled commissions
+							 * accepted = approved commissions
+							 */
+							case 'open':
+								$a_transaction['status'] = Utilities::STATUS_PENDING;
+								break;
+							case 'cancelled':
+								$a_transaction['status'] = Utilities::STATUS_DECLINED;
+								break;
+							case 'accepted':
+								$a_transaction['status'] = Utilities::STATUS_CONFIRMED;
+								break;
+						}
+						switch ($transaction['eventType']){
+							//Type of event LEAD or SALE
+							case 'SALE':
+								$a_transaction['event_type'] = Utilities::TYPE_SALE;
+								break;
+							case 'LEAD':
+								$a_transaction['event_type'] = Utilities::TYPE_LEAD;
+								break;
+						}
+						$a_transaction['referrer'] = $transaction['referer'];
+						$a_transaction['is_mobile'] = $transaction['isMobile'];
+						$totalTransactions[] = $a_transaction;
+					}
+					$page = (int)(1 + $page);
+				}
+			}
+		}
+		catch (\Exception $e){
+			throw new \Exception($e);
+		}
+
+		return $totalTransactions;
+
+	}
+
+
+	/**
+	 * @return string
+	 */
+	protected function _getApiBaseUrl() {
+		return $this->_apiUrl . $this->_apiVersion;
+	}
+
+	/**
+	 * @param  string $data
+	 * @param  string $format (Optional) Format
+	 * @return \stdClass
+	 */
+	protected function _decode($data, $format = 'json'){
+		if ($format == 'json') {
+			return json_decode($data, true);
+		}
+	}
+
+	/**
+	 * @param $service
+	 * @param $call
+	 * @param array $a_options
+	 * @return false|\stdClass|string
+	 * @throws \Exception
+	 */
+	protected function _request($service, $call, $a_options) {
+		$url = $this->_getApiBaseUrl() . '/' . $service . '/' . $call . '?';
+
+		foreach ($a_options as $key => $value) {
+			$url .= '&' . $key . '=' . $value;
+		}
+
+		$data = file_get_contents($url);
+		if (strlen($data) == 0) {
+			throw new \Exception('[AdCell][_request] invalid result received');
+		}
+
+		$data = $this->_decode($data);
+		if ($data['status'] == 200) {
+			return $data;
+		} else {
+			throw new \Exception($data['message']);
+		}
+	}
+
+
+
+
+}

--- a/Oara/Network/Publisher/Admitad.php
+++ b/Oara/Network/Publisher/Admitad.php
@@ -281,7 +281,9 @@ class Admitad extends \Oara\Network
 			$curl_results = curl_exec($ch);
 			curl_close($ch);
 			$coupons = json_decode($curl_results, true);
-
+            if (!is_array($coupons) || !isset($coupons['results'])) {
+                return $a_vouchers;
+            }
 			foreach ($coupons["results"] as $couponJson) {
 				$obj = Array();
 				$obj['promotionId'] = $couponJson["id"];

--- a/Oara/Network/Publisher/Admitad.php
+++ b/Oara/Network/Publisher/Admitad.php
@@ -1,64 +1,65 @@
 <?php
-namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
 
+namespace Oara\Network\Publisher;
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
 class Admitad extends \Oara\Network
 {
-    private $_client_id = null;
-    private $_client_secret = null;
-    private $_scope = null;
-    private $_grant_type = null;
-    private $_token = null;
+	private $_client_id = null;
+	private $_client_secret = null;
+	private $_scope = null;
+	private $_grant_type = null;
+	private $_token = null;
 
-    /**
-     * @param $credentials
-     * @throws Exception
-     */
-    public function login($credentials)
-    {
+	/**
+	 * @param $credentials
+	 * @throws Exception
+	 */
+	public function login($credentials)
+	{
 
-	    /**
-	     * https://github.com/admitad/admitad-php-api
-	     * https://developers.admitad.com/en/doc/api_en/auth/auth-client/
-	     * Client authorization
-	     * To authorize the user, it is required to send POST request to URL https://api.admitad.com/token/,
-	     * using data format application/x-www-form/urlencoded and transfer the following parameters
-	     * client_id
-	     * scope
-	     * grant_type
-	     *
-	     */
-        $this->_client_id = $credentials['user'];
-        $this->_client_secret = $credentials['password'];
-	    /**
-	     * https://developers.admitad.com/en/doc/api_en/auth/auth-rights/
-	     */
-        $this->_scope = 'public_data advcampaigns referrals coupons_for_website statistics';
-        $this->_grant_type = 'client_credentials';
+		/**
+		 * https://github.com/admitad/admitad-php-api
+		 * https://developers.admitad.com/en/doc/api_en/auth/auth-client/
+		 * Client authorization
+		 * To authorize the user, it is required to send POST request to URL https://api.admitad.com/token/,
+		 * using data format application/x-www-form/urlencoded and transfer the following parameters
+		 * client_id
+		 * scope
+		 * grant_type
+		 *
+		 */
+		$this->_client_id = $credentials['user'];
+		$this->_client_secret = $credentials['password'];
+		/**
+		 * https://developers.admitad.com/en/doc/api_en/auth/auth-rights/
+		 */
+		$this->_scope = 'public_data advcampaigns referrals coupons_for_website statistics';
+		$this->_grant_type = 'client_credentials';
 
-        $this->getToken();
-    }
+		$this->getToken();
+	}
 
 
-	public function getToken() {
+	public function getToken()
+	{
 		if (!empty($this->_token)) {
 			return $this->_token;
 		}
@@ -81,7 +82,7 @@ class Admitad extends \Oara\Network
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $loginUrl);
 		curl_setopt($ch, CURLOPT_POST, TRUE);
-		curl_setopt($ch,CURLOPT_POSTFIELDS, $post_params);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $post_params);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
@@ -97,27 +98,27 @@ class Admitad extends \Oara\Network
 	}
 
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials[] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials[] = $parameter;
 
-        return $credentials;
-    }
+		return $credentials;
+	}
 
 	/**
 	 * @return bool
@@ -128,208 +129,208 @@ class Admitad extends \Oara\Network
 		return $connection;
 	}
 
-    /**
-     * @return array
-     */
-    public function getMerchantList()
-    {
-        /**
-	     * https://developers.admitad.com/en/doc/api_en/methods/advcampaigns/advcampaigns-list/
-	     */
-	    $statisticsActions = "https://api.admitad.com/advcampaigns/";
-	    $limit = 100;
-	    $offset = 0;
-	    $loop = true;
-	    $merchants = Array();
-
-	    while ($loop){
-		    $ch = curl_init();
-		    curl_setopt($ch, CURLOPT_URL, $statisticsActions . '?limit=' . $limit .'&offset='. $offset);
-		    curl_setopt($ch, CURLOPT_POST, false);
-		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-		    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
-
-		    $curl_results = curl_exec($ch);
-		    curl_close($ch);
-		    $a_merchants = json_decode($curl_results, true);
-
-		    foreach ($a_merchants["results"] as $merchantJson) {
-			    $obj = Array();
-			    $obj['cid'] = $merchantJson["id"];
-			    $obj['name'] = $merchantJson["name"];
-			    $obj['status'] = $merchantJson["status"];
-			    $obj['url'] = $merchantJson["site_url"];
-			    $obj['launch_date'] = $merchantJson["activation_date"];
-			    $merchants[] = $obj;
-		    }
-		    if ((int)$a_merchants["_meta"]["count"] <= $offset) {
-			    $loop = false;
-		    }
-		    $offset = (int)($limit + $offset);
-	    }
-
-	    return $merchants;
-    }
-
-    /**
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-    	$totalTransactions = array();
-	    $limit = 100;
-	    $offset = 0;
-	    $loop = true;
-
-	    while ($loop){
-		    /**
-		     * https://developers.admitad.com/en/doc/api_en/methods/statistics/statistics-actions/
-		     * The values for dates should be in format %d.%m.%Y
-		     * Returns the result in the JSON format
-		     */
-		    $statisticsActions = "https://api.admitad.com/statistics/actions/";
-		    $params = array(
-			    new \Oara\Curl\Parameter('date_start',  $dStartDate->format("d.m.Y")),
-			    new \Oara\Curl\Parameter('date_end', $dEndDate->format("d.m.Y")),
-		        new \Oara\Curl\Parameter('limit', $limit),
-		        new \Oara\Curl\Parameter('offset', $offset)
-	    );
-
-	    $p = array();
-	    foreach ($params as $parameter) {
-		    $p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
-	    }
-	    $get_params = implode('&', $p);
-
-	    $ch = curl_init();
-	    curl_setopt($ch, CURLOPT_URL, $statisticsActions . '?' . $get_params);
-	    curl_setopt($ch, CURLOPT_POST, false);
-	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-	    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
-
-	    $curl_results = curl_exec($ch);
-	    curl_close($ch);
-	    $transactionsList = json_decode($curl_results, true);
-
-		    foreach ($transactionsList['results'] as $transactionJson) {
-
-			    $transaction = Array();
-			    $transaction['unique_id'] = $transactionJson["action_id"];
-			    $transaction['merchantId'] = $transactionJson["advcampaign_id"];
-			    $transaction['merchantName'] = $transactionJson["advcampaign_name"];
-			    $transaction['date'] = $transactionJson["action_date"];
-			    $transaction['click_date'] = $transactionJson["click_date"];
-			    $transaction['update_date'] = $transactionJson["status_updated"];
-			    $transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson["cart"]);
-			    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson["payment"]);
-			    $transaction['currency'] = $transactionJson["currency"];
-			    $transaction['custom_id'] = $transactionJson["subid"];
-			    $transaction['IP'] = $transactionJson["click_user_ip"];
-			    $transaction['action'] = $transactionJson["action_type"];
-			    if ($transactionJson["status"] == 'pending' || strpos($transactionJson["status"], 'hold') == true || strpos($transactionJson["status"], 'stalled') == true){
-				    $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-			    }
-			    else if ($transactionJson["status"] == 'declined'){
-				    $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-			    }
-			    else if (strpos($transactionJson["status"], 'confirmed') == true){
-				    $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-			    }
-			    else if (strpos($transactionJson["status"], 'approved') == true){
-				    $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-			    }
-			    else{
-				    $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-				    echo "[php-oara][Oara][Network][Publisher][Admitad] Transaction status unexpected " . $transactionJson["status"];
-				}
-			    $totalTransactions[] = $transaction;
-		    }
-		    if ((int)$transactionsList["_meta"]["count"] <= $offset) {
-			    $loop = false;
-		    }
-		    $offset = (int)($limit + $offset);
-	    }
-	    return $totalTransactions;
-
-    }
-
 	/**
 	 * @return array
+	 * @throws \Exception
 	 */
-	public function getVouchers($idSite) {
+	public function getMerchantList()
+	{
+		$merchants = Array();
+		try {
+			//https://developers.admitad.com/en/doc/api_en/methods/advcampaigns/advcampaigns-list/
+			$statisticsActions = "https://api.admitad.com/advcampaigns/";
+			$limit = 100;
+			$offset = 0;
+			$loop = true;
 
-		/**
-		 * https://developers.admitad.com/en/doc/api_en/methods/coupons/coupons-website/
-		 */
-		$couponsWebsite = "https://api.admitad.com/coupons/website/" . $idSite . '/';
+			while ($loop) {
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_URL, $statisticsActions . '?limit=' . $limit . '&offset=' . $offset);
+				curl_setopt($ch, CURLOPT_POST, false);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
 
-		$limit = 100;
-		$offset = 0;
-		$loop = true;
-		$a_vouchers = Array();
-
-		while ($loop){
-			$ch = curl_init();
-			curl_setopt($ch, CURLOPT_URL, $couponsWebsite . '?limit=' . $limit .'&offset='. $offset);
-			curl_setopt($ch, CURLOPT_POST, false);
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-			curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
-
-			$curl_results = curl_exec($ch);
-			curl_close($ch);
-			$coupons = json_decode($curl_results, true);
-            if (!is_array($coupons) || !isset($coupons['results'])) {
-                return $a_vouchers;
-            }
-			foreach ($coupons["results"] as $couponJson) {
-				$obj = Array();
-				$obj['promotionId'] = $couponJson["id"];
-				$obj['advertiser_id'] = $couponJson["campaign"]["id"];
-				$obj['advertiser_name'] = $couponJson["campaign"]["name"];
-				if ($couponJson["species"] == 'promocode'){
-					$obj['code'] = $couponJson["promocode"];
+				$curl_results = curl_exec($ch);
+				curl_close($ch);
+				$a_merchants = json_decode($curl_results, true);
+				foreach ($a_merchants['results'] as $merchantJson) {
+					$obj = Array();
+					$obj['cid'] = $merchantJson["id"];
+					$obj['name'] = $merchantJson["name"];
+					$obj['status'] = $merchantJson["status"];
+					$obj['url'] = $merchantJson["site_url"];
+					$obj['launch_date'] = $merchantJson["activation_date"];
+					$merchants[] = $obj;
 				}
-				else {
-					$obj['code'] = null;
+				if ((int)$a_merchants['_meta']['count'] <= $offset) {
+					$loop = false;
 				}
-				$obj['is_exclusive'] = $couponJson["exclusive"];
-				$obj['name'] = $couponJson["name"];
-				$obj['short_description'] = $couponJson["short_name"];
-				$obj['description'] = $couponJson["description"];
-				$obj['discount_amount'] = abs((int)$couponJson["discount"]);
-				$obj['is_percentage'] = (bool)(strpos($couponJson["discount"], '%') !== false);
-				$obj['restriction'] = null;
-				$obj['start_date'] = $couponJson["date_start"];
-				$obj['end_date'] = $couponJson["date_end"];
-				$obj['tracking'] = $couponJson["goto_link"];
-				// species: Kind of coupon (‘promocode’, ‘action’ - special offer or deal)
-				switch ($couponJson["species"]) {
-					case 'promocode':
-						$obj['type'] = \Oara\Utilities::OFFER_TYPE_VOUCHER;
-						break;
-					case 'action':
-						$obj['type'] = \Oara\Utilities::OFFER_TYPE_DISCOUNT;
-						break;
-					default:
-						$obj['type'] = \Oara\Utilities::OFFER_TYPE_DISCOUNT;
-						echo "[php-oara][Oara][Network][Publisher][Admitad] Coupon type unexpected " . $couponJson["type"];
-						break;
-				}
-
-				$a_vouchers[] = $obj;
+				$offset = (int)($limit + $offset);
 			}
-			if ((int)$coupons["_meta"]["count"] <= $offset) {
-				$loop = false;
-			}
-			$offset = (int)($limit + $offset);
+		} catch (\Exception $e) {
+			throw new \Exception('[php-oara][Oara][Network][Publisher][Admitad][getMerchantList][Exception] ' . $e->getMessage());
 		}
-		return $a_vouchers;
+		return $merchants;
 	}
 
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$totalTransactions = array();
+		try {
+			$limit = 100;
+			$offset = 0;
+			$loop = true;
 
+			while ($loop) {
+				/**
+				 * https://developers.admitad.com/en/doc/api_en/methods/statistics/statistics-actions/
+				 * The values for dates should be in format %d.%m.%Y
+				 * Returns the result in the JSON format
+				 */
+				$statisticsActions = "https://api.admitad.com/statistics/actions/";
+				$params = array(
+					new \Oara\Curl\Parameter('date_start', $dStartDate->format("d.m.Y")),
+					new \Oara\Curl\Parameter('date_end', $dEndDate->format("d.m.Y")),
+					new \Oara\Curl\Parameter('limit', $limit),
+					new \Oara\Curl\Parameter('offset', $offset)
+				);
+
+				$p = array();
+				foreach ($params as $parameter) {
+					$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+				}
+				$get_params = implode('&', $p);
+
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_URL, $statisticsActions . '?' . $get_params);
+				curl_setopt($ch, CURLOPT_POST, false);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
+
+				$curl_results = curl_exec($ch);
+				curl_close($ch);
+				$transactionsList = json_decode($curl_results, true);
+				foreach ($transactionsList['results'] as $transactionJson) {
+
+					$transaction = Array();
+					$transaction['unique_id'] = $transactionJson["action_id"];
+					$transaction['merchantId'] = $transactionJson["advcampaign_id"];
+					$transaction['merchantName'] = $transactionJson["advcampaign_name"];
+					$transaction['date'] = $transactionJson["action_date"];
+					$transaction['click_date'] = $transactionJson["click_date"];
+					$transaction['update_date'] = $transactionJson["status_updated"];
+					$transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson["cart"]);
+					$transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson["payment"]);
+					$transaction['currency'] = $transactionJson["currency"];
+					$transaction['custom_id'] = $transactionJson["subid"];
+					$transaction['IP'] = $transactionJson["click_user_ip"];
+					$transaction['action'] = $transactionJson["action_type"];
+					if ($transactionJson['status'] == 'pending' || strpos($transactionJson['status'], 'hold') !== false || strpos($transactionJson['status'], 'stalled') !== false || strpos($transactionJson['status'], 'delayed') !== false) {
+						$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+					} else if ($transactionJson['status'] == 'declined') {
+						$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+					} else if ($transactionJson['status'] == 'confirmed' || $transactionJson['status'] == 'approved') {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} else {
+						$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						echo '[php-oara][Oara][Network][Publisher][Admitad][getTransactionList] Transaction status unexpected ' . $transactionJson['status'];
+					}
+					$totalTransactions[] = $transaction;
+				}
+				if ((int)$transactionsList['_meta']['count'] <= $offset) {
+					$loop = false;
+				}
+				$offset = (int)($limit + $offset);
+			}
+		} catch (\Exception $e) {
+			throw new \Exception('[php-oara][Oara][Network][Publisher][Admitad][getTransactionList][Exception] ' . $e->getMessage());
+		}
+		return $totalTransactions;
+	}
+
+	/**
+	 * @param $idSite
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getVouchers($idSite)
+	{
+		$a_vouchers = Array();
+		try {
+			//https://developers.admitad.com/en/doc/api_en/methods/coupons/coupons-website/
+			$couponsWebsite = "https://api.admitad.com/coupons/website/" . $idSite . '/';
+
+			$limit = 100;
+			$offset = 0;
+			$loop = true;
+
+			while ($loop) {
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_URL, $couponsWebsite . '?limit=' . $limit . '&offset=' . $offset);
+				curl_setopt($ch, CURLOPT_POST, false);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
+
+				$curl_results = curl_exec($ch);
+				curl_close($ch);
+				$coupons = json_decode($curl_results, true);
+				if (!is_array($coupons) || !isset($coupons['results'])) {
+					return $a_vouchers;
+				}
+				foreach ($coupons["results"] as $couponJson) {
+					$obj = Array();
+					$obj['promotionId'] = $couponJson["id"];
+					$obj['advertiser_id'] = $couponJson["campaign"]["id"];
+					$obj['advertiser_name'] = $couponJson["campaign"]["name"];
+					if ($couponJson["species"] == 'promocode') {
+						$obj['code'] = $couponJson["promocode"];
+					} else {
+						$obj['code'] = null;
+					}
+					$obj['is_exclusive'] = $couponJson["exclusive"];
+					$obj['name'] = $couponJson["name"];
+					$obj['short_description'] = $couponJson["short_name"];
+					$obj['description'] = $couponJson["description"];
+					$obj['discount_amount'] = abs((int)$couponJson["discount"]);
+					$obj['is_percentage'] = (bool)(strpos($couponJson["discount"], '%') !== false);
+					$obj['restriction'] = null;
+					$obj['start_date'] = $couponJson["date_start"];
+					$obj['end_date'] = $couponJson["date_end"];
+					$obj['tracking'] = $couponJson["goto_link"];
+					// species: Kind of coupon (‘promocode’, ‘action’ - special offer or deal)
+					switch ($couponJson["species"]) {
+						case 'promocode':
+							$obj['type'] = \Oara\Utilities::OFFER_TYPE_VOUCHER;
+							break;
+						case 'action':
+							$obj['type'] = \Oara\Utilities::OFFER_TYPE_DISCOUNT;
+							break;
+						default:
+							$obj['type'] = \Oara\Utilities::OFFER_TYPE_DISCOUNT;
+							echo "[php-oara][Oara][Network][Publisher][Admitad][getVouchers] Coupon type unexpected " . $couponJson["type"];
+							break;
+					}
+
+					$a_vouchers[] = $obj;
+				}
+				if ((int)$coupons["_meta"]["count"] <= $offset) {
+					$loop = false;
+				}
+				$offset = (int)($limit + $offset);
+			}
+		} catch (\Exception $e) {
+			throw new \Exception('[php-oara][Oara][Network][Publisher][Admitad][getVouchers][Exception] ' . $e->getMessage());
+		}
+
+		return $a_vouchers;
+	}
 
 
 }

--- a/Oara/Network/Publisher/AffiliNet.php
+++ b/Oara/Network/Publisher/AffiliNet.php
@@ -111,7 +111,7 @@ class AffiliNet extends \Oara\Network
                 $obj['name'] = $merchant->ProgramTitle;
                 // Added more info - 2018-04-20 <PN>
                 $obj['url'] = $merchant->Url;
-                $obj['status'] = $merchant->PartnershipStatus ?? null;
+                $obj['status'] = isset($merchant->PartnershipStatus) ? $merchant->PartnershipStatus : null;
                 $obj['launch_date'] = $merchant->LaunchDate;
                 $merchantListResult[] = $obj;
             }

--- a/Oara/Network/Publisher/AffiliNet.php
+++ b/Oara/Network/Publisher/AffiliNet.php
@@ -111,7 +111,7 @@ class AffiliNet extends \Oara\Network
                 $obj['name'] = $merchant->ProgramTitle;
                 // Added more info - 2018-04-20 <PN>
                 $obj['url'] = $merchant->Url;
-                $obj['status'] = $merchant->PartnershipStatus;
+                $obj['status'] = $merchant->PartnershipStatus ?? null;
                 $obj['launch_date'] = $merchant->LaunchDate;
                 $merchantListResult[] = $obj;
             }

--- a/Oara/Network/Publisher/AffiliNet.php
+++ b/Oara/Network/Publisher/AffiliNet.php
@@ -139,14 +139,20 @@ class AffiliNet extends \Oara\Network
 
         while ($voucherRead < $totalResults && $currentPage < 9) {
             $voucherList = self::affilinetCall('voucher', $publisherInboxService, $params, 0, $currentPage);
-            $totalResults = $voucherList->TotalResults;
-            $vouchers = $voucherList->VoucherCodeCollection->VoucherCodeItem;
-            $voucherRead += count($vouchers);
-            $currentPage++;
+            if (isset($voucherList->TotalResults) && isset($voucherList->VoucherCodeCollection) && isset($voucherList->VoucherCodeCollection->VoucherCodeItem)){
+	            $totalResults = $voucherList->TotalResults;
+	            $vouchers = $voucherList->VoucherCodeCollection->VoucherCodeItem;
+	            $voucherRead += count($vouchers);
+	            $currentPage++;
 
-            foreach($vouchers as $voucherItem) {
-                $vouchersListResult[] = $voucherItem;
+	            foreach($vouchers as $voucherItem) {
+		            $vouchersListResult[] = $voucherItem;
+	            }
             }
+            else{
+	            return $vouchersListResult;
+            }
+
         }
         return $vouchersListResult;
     }

--- a/Oara/Network/Publisher/AffiliateFuture.php
+++ b/Oara/Network/Publisher/AffiliateFuture.php
@@ -293,7 +293,7 @@ class AffiliateFuture extends \Oara\Network
 
                         $obj = Array();
                         $obj['currency'] = 'GBP'; // Affiliate Future doesn't handle currencies, default is Pound!
-                        $obj['merchantId'] = self::findAttribute($transaction, 'ProgrammeID');
+                        $obj['merchantId'] = self::findAttribute($transaction, 'MerchantID');
                         $obj['date'] = $date->format("Y-m-d H:i:s");
                         if (self::findAttribute($transaction, 'TrackingReference') != null) {
                             $obj['custom_id'] = self::findAttribute($transaction, 'TrackingReference');

--- a/Oara/Network/Publisher/AffiliateFuture.php
+++ b/Oara/Network/Publisher/AffiliateFuture.php
@@ -287,7 +287,7 @@ class AffiliateFuture extends \Oara\Network
                 foreach ($xml->TransactionList as $transaction) {
                     $date = new \DateTime(self::findAttribute($transaction, 'TransactionDate'));
 
-                    if (count($merchantIdMap)== 0 || isset($merchantIdMap[(int)self::findAttribute($transaction, 'ProgrammeID')]) &&
+                    if (count($merchantIdMap)== 0 || isset($merchantIdMap[(int)self::findAttribute($transaction, 'MerchantID')]) &&
                         ($date->format("Y-m-d H:i:s") >= $dStartDate->format("Y-m-d H:i:s")) &&
                         ($date->format("Y-m-d H:i:s") <= $dEndDate->format("Y-m-d H:i:s"))) {
 

--- a/Oara/Network/Publisher/AffiliateWindow.php
+++ b/Oara/Network/Publisher/AffiliateWindow.php
@@ -226,7 +226,7 @@ class AffiliateWindow extends \Oara\Network
                         else if (property_exists($transactionObject->clickRefs,'clickRef2') && $transactionObject->clickRefs->clickRef2 != null && $transactionObject->clickRefs->clickRef2 !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef2;
                         else if (property_exists($transactionObject->clickRefs,'clickRef3') && $transactionObject->clickRefs->clickRef3 != null && $transactionObject->clickRefs->clickRef3 !== 0)
-                            $$transaction['custom_id'] = $transactionObject->clickRefs->clickRef3;
+                            $transaction['custom_id'] = $transactionObject->clickRefs->clickRef3;
                         else if (property_exists($transactionObject->clickRefs,'clickRef4') && $transactionObject->clickRefs->clickRef4 != null && $transactionObject->clickRefs->clickRef4 !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef4;
                         else if (property_exists($transactionObject->clickRefs,'clickRef5') && $transactionObject->clickRefs->clickRef5 != null && $transactionObject->clickRefs->clickRef5 !== 0)

--- a/Oara/Network/Publisher/AffiliateWindow.php
+++ b/Oara/Network/Publisher/AffiliateWindow.php
@@ -195,8 +195,13 @@ class AffiliateWindow extends \Oara\Network
             $pwd = $this->_credentials["apipassword"];
             $dStartDate_ = $dStartDate->format("Y-m-d");
             $dStartTime_ = "00:00:00";
-            $dEndDate_ = $dEndDate->format("Y-m-d");
-            $dEndTime_ = "23:59:59";
+	        $dEndDate_ = $dEndDate->format("Y-m-d");
+	        if ($dEndDate_ == date("Y-m-d")){
+		        $dEndTime_ = date("H:i:s");
+	        }
+	        else{
+		        $dEndTime_ = "23:59:59";
+	        }
             $dEndDate = urlencode($dEndDate_ . "T" . $dEndTime_);
             $dStartDate = urlencode($dStartDate_ . "T" . $dStartTime_);
             $timezone = urlencode($this->_timeZone);

--- a/Oara/Network/Publisher/AffiliateWindow.php
+++ b/Oara/Network/Publisher/AffiliateWindow.php
@@ -229,7 +229,15 @@ class AffiliateWindow extends \Oara\Network
                         $transaction['custom_id'] = $transactionObject->clickRefs->clickRef;
                     }
                     $transaction['type'] = $transactionObject->type;
-                    $transaction['status'] = ($transactionObject->commissionStatus == 'approved') ? 'confirmed' : $transactionObject->commissionStatus;
+                    if($transactionObject->commissionStatus == 'approved'){
+                        $transaction['status'] = 'confirmed';
+                    }
+                    elseif($transactionObject->commissionStatus == 'declined' || $transactionObject->commissionStatus == 'deleted'){
+                        $transaction['status'] = 'declined';
+                    }
+                    elseif($transactionObject->commissionStatus == 'pending'){
+                        $transaction['status'] = 'pending';
+                    }
                     $transaction['amount'] = \Oara\Utilities::parseDouble($transactionObject->saleAmount->amount);
                     $transaction['commission'] = \Oara\Utilities::parseDouble($transactionObject->commissionAmount->amount);
                     $transaction['currency'] = $transactionObject->commissionAmount->currency;

--- a/Oara/Network/Publisher/AffiliateWindow.php
+++ b/Oara/Network/Publisher/AffiliateWindow.php
@@ -221,17 +221,17 @@ class AffiliateWindow extends \Oara\Network
                     $transaction['date'] = $date->format("Y-m-d H:i:s");
                     $transaction['custom_id'] = '';
                     if (is_object($transactionObject->clickRefs)) {
-                        if (property_exists($transactionObject->clickRefs,'clickRef') && $transactionObject->clickRefs->clickRef != null && $transactionObject->clickRefs->clickRef != 0)
+                        if (property_exists($transactionObject->clickRefs,'clickRef') && $transactionObject->clickRefs->clickRef != null && $transactionObject->clickRefs->clickRef !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef;
-                        else if (property_exists($transactionObject->clickRefs,'clickRef2') && $transactionObject->clickRefs->clickRef2 != null && $transactionObject->clickRefs->clickRef2 != 0)
+                        else if (property_exists($transactionObject->clickRefs,'clickRef2') && $transactionObject->clickRefs->clickRef2 != null && $transactionObject->clickRefs->clickRef2 !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef2;
-                        else if (property_exists($transactionObject->clickRefs,'clickRef3') && $transactionObject->clickRefs->clickRef3 != null && $transactionObject->clickRefs->clickRef3 != 0)
+                        else if (property_exists($transactionObject->clickRefs,'clickRef3') && $transactionObject->clickRefs->clickRef3 != null && $transactionObject->clickRefs->clickRef3 !== 0)
                             $$transaction['custom_id'] = $transactionObject->clickRefs->clickRef3;
-                        else if (property_exists($transactionObject->clickRefs,'clickRef4') && $transactionObject->clickRefs->clickRef4 != null && $transactionObject->clickRefs->clickRef4 != 0)
+                        else if (property_exists($transactionObject->clickRefs,'clickRef4') && $transactionObject->clickRefs->clickRef4 != null && $transactionObject->clickRefs->clickRef4 !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef4;
-                        else if (property_exists($transactionObject->clickRefs,'clickRef5') && $transactionObject->clickRefs->clickRef5 != null && $transactionObject->clickRefs->clickRef5 != 0)
+                        else if (property_exists($transactionObject->clickRefs,'clickRef5') && $transactionObject->clickRefs->clickRef5 != null && $transactionObject->clickRefs->clickRef5 !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef5;
-                        else if (property_exists($transactionObject->clickRefs,'clickRef6') && $transactionObject->clickRefs->clickRef6 != null && $transactionObject->clickRefs->clickRef6 != 0)
+                        else if (property_exists($transactionObject->clickRefs,'clickRef6') && $transactionObject->clickRefs->clickRef6 != null && $transactionObject->clickRefs->clickRef6 !== 0)
                             $transaction['custom_id'] = $transactionObject->clickRefs->clickRef6;
                     }
                     $transaction['type'] = $transactionObject->type;

--- a/Oara/Network/Publisher/CommissionJunction.php
+++ b/Oara/Network/Publisher/CommissionJunction.php
@@ -392,8 +392,16 @@ class CommissionJunction extends \Oara\Network
         }
         else {
             if ($xml->count() > 0) {
-                foreach($xml->children() as $key => $value) {
-                    echo $key .  ": " . (string) $value . PHP_EOL;
+                if (isset($xml->title)) {
+                    echo "[ERROR][CJ] " . (string) $xml->title . PHP_EOL;
+                }
+                foreach($xml->children() as $child) {
+                    $key = $child->getName();
+                    $value = $child->attributes();
+                    echo "[WARNING][CJ] " . $key .  ": " . (string) $value . PHP_EOL;
+                    foreach ($child->children() AS $subkey => $value) {
+                        echo "[WARNING][CJ] " . $subkey .  ": " . (string) $value . PHP_EOL;
+                    }
                 }
             }
         }

--- a/Oara/Network/Publisher/CommissionJunctionGraphQL.php
+++ b/Oara/Network/Publisher/CommissionJunctionGraphQL.php
@@ -118,7 +118,7 @@ class CommissionJunctionGraphQL extends \Oara\Network
                 }
             
                 if ($singleTransaction['pubCommissionAmountPubCurrency'] == 0) {
-                    $transactions[$i]['status'] = \Oara\Utilities::STATUS_PENDING;
+                    $transactions[$i]['status'] = \Oara\Utilities::STATUS_DECLINED;
                 }	
             
                 $transactions[$i]['aid']                = $singleTransaction['aid'];

--- a/Oara/Network/Publisher/CommissionJunctionGraphQL.php
+++ b/Oara/Network/Publisher/CommissionJunctionGraphQL.php
@@ -1,0 +1,133 @@
+<?php
+namespace Oara\Network\Publisher;
+    /**
+     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+     *
+     * Copyright (C) 2016  Fubra Limited
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Affero General Public License as published by
+     * the Free Software Foundation, either version 3 of the License, or any later version.
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Affero General Public License for more details.
+     * You should have received a copy of the GNU Affero General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+     * Contact
+     * ------------
+     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+     **/
+/**
+ * Export Class
+ *
+ * @author     Slawek Naczynski
+ * @category   Cj
+ * @copyright  Fubra Limited
+ * @version    Release: 01.00
+ *
+ */
+class CommissionJunctionGraphQL extends \Oara\Network
+{
+    private $_website_id  = null;
+    private $_apiPassword = null;
+
+    /**
+     * @param $credentials
+     */
+    public function login($credentials)
+    {
+        if(isset($credentials['apipassword']) && isset($credentials['id_site'])){
+            $this->_apiPassword = $credentials['apipassword'];
+            $this->_website_id  = $credentials['id_site'];
+        }
+        else{
+            return false;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function checkConnection()
+    {
+        $connection = true;
+        $result = self::apiCall(new \DateTime('2000-01-01'), new \DateTime('2000-01-02'));
+        if ($result === false) {
+            return false;
+        }
+        return $connection;
+    }
+
+    private function apiCall($startDate, $endDate)
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, 'https://commissions.api.cj.com/query');
+        curl_setopt($ch, CURLOPT_POSTFIELDS, '{ publisherCommissions(forPublishers: ["' . $this->_website_id . '"], sincePostingDate:"' . $startDate->format("Y-m-d") . 'T00:00:00Z",beforePostingDate:"' . $endDate->format("Y-m-d") . 'T23:59:59Z"){count payloadComplete records {actionStatus originalActionId commissionId advertiserId shopperId pubCommissionAmountPubCurrency original aid orderId eventDate saleAmountPubCurrency actionType }  } }');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($ch, CURLOPT_POST, TRUE);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer ' . $this->_apiPassword));
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+        
+        $result = curl_exec($ch);
+        curl_close ($ch);
+        return json_decode($result, true);
+    }
+
+    /**
+     * @return array
+     */
+    public function getMerchantList()
+    {
+        $merchants = array();
+        return $merchants;
+    }
+
+    /**
+     * @param null $merchantList
+     * @param \DateTime|null $dStartDate
+     * @param \DateTime|null $dEndDate
+     * @return array
+     * @throws Exception
+     */
+    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+    {
+        $result       = self::apiCall($dStartDate, $dEndDate);
+        $transactions = array();
+        $i            = 0;
+
+        // IF THERE ARE ANY RESULTS
+        if(isset($result) && count($result) > 0 && $result['data']['publisherCommissions']['count'] > 0){
+            foreach($result['data']['publisherCommissions']['records'] as $singleTransaction){
+                $transactions[$i]['unique_id']  = $singleTransaction['commissionId'];
+                $transactions[$i]['action']     = $singleTransaction['actionType'];
+                $transactions[$i]['merchantId'] = $singleTransaction['advertiserId'];
+                $transactions[$i]['date']       = $singleTransaction['eventDate'];
+                $transactions[$i]['custom_id']  = $singleTransaction['shopperId'];
+                $transactions[$i]['amount']     = \Oara\Utilities::parseDouble($singleTransaction['saleAmountPubCurrency']);
+                $transactions[$i]['commission'] = \Oara\Utilities::parseDouble($singleTransaction['pubCommissionAmountPubCurrency']);
+                
+                if ($singleTransaction['actionStatus'] == 'locked' || $singleTransaction['actionStatus'] == 'closed') {
+                    $transactions[$i]['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+                } else if ($singleTransaction['actionStatus'] == 'extended' || $singleTransaction['actionStatus'] == 'new') {
+                    $transactions[$i]['status'] = \Oara\Utilities::STATUS_PENDING;
+                } else if ($singleTransaction['actionStatus'] == 'corrected') {
+                    $transactions[$i]['status'] = \Oara\Utilities::STATUS_DECLINED;
+                }
+            
+                if ($singleTransaction['pubCommissionAmountPubCurrency'] == 0) {
+                    $transactions[$i]['status'] = \Oara\Utilities::STATUS_PENDING;
+                }	
+            
+                $transactions[$i]['aid']                = $singleTransaction['aid'];
+                $transactions[$i]['order-id']           = $singleTransaction['orderId'];
+                $transactions[$i]['original']           = ($singleTransaction['original'] === true);
+                $transactions[$i]['original-action-id'] = $singleTransaction['originalActionId'];
+                $i++;
+            }
+        }
+        return $transactions;
+    }
+}

--- a/Oara/Network/Publisher/Daisycon.php
+++ b/Oara/Network/Publisher/Daisycon.php
@@ -1,24 +1,26 @@
 <?php
+
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+
 /**
  * Export Class
  *
@@ -31,269 +33,275 @@ namespace Oara\Network\Publisher;
 class Daisycon extends \Oara\Network
 {
 
-    private $_credentials = null;
+	private $_credentials = null;
 
-    private $_publisherId = array();
+	private $_publisherId = array();
 
-    /**
-     * @param $credentials
-     */
-    public function login($credentials)
-    {
-        $this->_credentials = $credentials;
-    }
+	/**
+	 * @param $credentials
+	 */
+	public function login($credentials)
+	{
+		$this->_credentials = $credentials;
+	}
 
-    /**
-     * Check the connection
-     */
-    public function checkConnection()
-    {
-        //If not login properly the construct launch an exception
-        $connection = true;
+	/**
+	 * Check the connection
+	 */
+	public function checkConnection()
+	{
+		//If not login properly the construct launch an exception
+		$connection = true;
 
-        try {
-            $user = $this->_credentials['user'];
-            $password = $this->_credentials['password'];
+		try {
+			$user = $this->_credentials['user'];
+			$password = $this->_credentials['password'];
 
 
-            $url = "https://services.daisycon.com:443/publishers?page=1&per_page=100";
-            // initialize curl resource
-            $ch = \curl_init();
-            // set the http request authentication headers
-            $headers = array('Authorization: Basic ' . \base64_encode($user . ':' . $password));
-            // set curl options
-            \curl_setopt($ch, CURLOPT_URL, $url);
-            \curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-            \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            // execute curl
-            $response = \curl_exec($ch);
-            $publisherList = \json_decode($response, true);
-            foreach ($publisherList as $publisher) {
-                $this->_publisherId[] = $publisher["id"];
-            }
-            if (\count($this->_publisherId) == 0) {
-                throw new \Exception("No publisher found");
-            }
+			$url = "https://services.daisycon.com:443/publishers?page=1&per_page=100";
+			// initialize curl resource
+			$ch = curl_init();
+			// set the http request authentication headers
+			$headers = array('Authorization: Basic ' . base64_encode($user . ':' . $password));
+			// set curl options
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			// execute curl
+			$response = curl_exec($ch);
+			$publisherList = json_decode($response, true);
+			foreach ($publisherList as $publisher) {
+				$this->_publisherId[] = $publisher["id"];
+			}
+			if (count($this->_publisherId) == 0) {
+				throw new \Exception("No publisher found");
+			}
 
-        } catch (\Exception $e) {
-            $connection = false;
-        }
-        return $connection;
-    }
+		} catch (\Exception $e) {
+			$connection = false;
+		}
+		return $connection;
+	}
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials["password"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials["password"] = $parameter;
 
-        return $credentials;
-    }
+		return $credentials;
+	}
 
-    /**
-     * (non-PHPdoc)
-     * @see library/Oara/Network/Interface#getMerchantList()
-     */
-    public function getMerchantList()
-    {
-        $merchants = array();
-        $user = $this->_credentials['user'];
-        $password = $this->_credentials['password'];
-        $id_site = $this->_credentials['idSite'];      // publisher id to retrieve (empty = all publishers)
+	/**
+	 * (non-PHPdoc)
+	 * @see library/Oara/Network/Interface#getMerchantList()
+	 */
+	public function getMerchantList()
+	{
+		$merchants = array();
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$id_site = $this->_credentials['idSite'];      // publisher id to retrieve (empty = all publishers)
 
-        foreach ($this->_publisherId as $publisherId) {
-            if (!empty($id_site) && $publisherId != $id_site) {
-                // Skip unwanted publisher accounts
-                continue;
-            }
-            $page = 1;
-            $pageSize = 100;
-            $finish = false;
+		foreach ($this->_publisherId as $publisherId) {
+			if (!empty($id_site) && $publisherId != $id_site) {
+				// Skip unwanted publisher accounts
+				continue;
+			}
+			$page = 1;
+			$pageSize = 100;
+			$finish = false;
 
-            while (!$finish) {
-                $url = "https://services.daisycon.com:443/publishers/$publisherId/programs?page=$page&per_page=$pageSize";
-                // initialize curl resource
-                $ch = \curl_init();
-                // set the http request authentication headers
-                $headers = array('Authorization: Basic ' . \base64_encode($user . ':' . $password));
-                // set curl options
-                \curl_setopt($ch, CURLOPT_URL, $url);
-                \curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-                \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                // execute curl
-                $response = \curl_exec($ch);
-                $merchantList = \json_decode($response, true);
+			while (!$finish) {
+				$url = "https://services.daisycon.com:443/publishers/$publisherId/programs?page=$page&per_page=$pageSize";
+				// initialize curl resource
+				$ch = curl_init();
+				// set the http request authentication headers
+				$headers = array('Authorization: Basic ' . base64_encode($user . ':' . $password));
+				// set curl options
+				curl_setopt($ch, CURLOPT_URL, $url);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+				// execute curl
+				$response = curl_exec($ch);
+				$merchantList = json_decode($response, true);
 
-                foreach ($merchantList as $merchant) {
-                    // if ($merchant['status'] == 'active') {
-                        $obj = Array();
-                        $obj['cid'] = $merchant['id'];
-                        $obj['name'] = $merchant['name'];
-                        // Added more info - 2018-06-01 <PN>
-                        $obj['status'] = $merchant['status'];
-                        $obj["display_url"] = $merchant['display_url'];
-                        $obj["start_date"] = $merchant['startdate'];
-                        $obj["end_date"] = $merchant['enddate'];
-                        $merchants[] = $obj;
-                    // }
-                }
+				foreach ($merchantList as $merchant) {
 
-                if (\count($merchantList) != $pageSize) {
-                    $finish = true;
-                }
-                $page++;
-            }
-        }
-        return $merchants;
-    }
+					$obj = Array();
+					$obj['cid'] = $merchant['id'];
+					$obj['name'] = $merchant['name'];
+					// Added more info - 2018-06-01 <PN>
+					$obj['status'] = $merchant['status'];
+					$obj["display_url"] = $merchant['display_url'];
+					$obj["start_date"] = $merchant['startdate'];
+					$obj["end_date"] = $merchant['enddate'];
+					$merchants[] = $obj;
+				}
 
-    /**
-     * @param null $merchantList                array of merchants id to retrieve transactions (empty array or null = all merchants)
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     * @throws Exception
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-        $totalTransactions = array();
+				if (count($merchantList) != $pageSize) {
+					$finish = true;
+				}
+				$page++;
+			}
+		}
+		return $merchants;
+	}
 
-        $merchantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
+	/**
+	 * @param null $merchantList array of merchants id to retrieve transactions (empty array or null = all merchants)
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$totalTransactions = array();
 
-        $user = $this->_credentials['user'];
-        $password = $this->_credentials['password'];
-        $id_site = $this->_credentials['idSite'];      // publisher id to retrieve (empty = all publishers)
+		$merchantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
 
-        foreach ($this->_publisherId as $publisherId) {
-            if (!empty($id_site) && $publisherId != $id_site) {
-                // Skip unwanted publisher accounts
-                continue;
-            }
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$id_site = $this->_credentials['idSite'];      // publisher id to retrieve (empty = all publishers)
 
-            $page = 1;
-            $pageSize = 100;
-            $finish = false;
+		foreach ($this->_publisherId as $publisherId) {
+			if (!empty($id_site) && $publisherId != $id_site) {
+				// Skip unwanted publisher accounts
+				continue;
+			}
 
-            while (!$finish) {
-                $url = "https://services.daisycon.com:443/publishers/$publisherId/transactions?page=$page&per_page=$pageSize&start=" . \urlencode($dStartDate->format("Y-m-d H:i:s")) . "&end=" . \urlencode($dEndDate->format("Y-m-d H:i:s"));
-                // initialize curl resource
-                $ch = \curl_init();
-                // set the http request authentication headers
-                $headers = array('Authorization: Basic ' . \base64_encode($user . ':' . $password));
-                // set curl options
-                \curl_setopt($ch, CURLOPT_URL, $url);
-                \curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-                \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                // execute curl
-                $response = \curl_exec($ch);
-                $transactionList = \json_decode($response, true);
+			$page = 1;
+			$pageSize = 100;
+			$finish = false;
 
-                foreach ($transactionList as $transaction) {
-                    $merchantId = $transaction['program_id'];
-                    if (is_array($merchantList) && count($merchantList) > 0 && !isset($merchantIdList[$merchantId])) {
-                        // Skip unwanted merchants (empty merchant array means "all" merchants)
-                        continue;
-                    }
-                    if (!isset($transaction['parts']) || count($transaction['parts']) == 0) {
-                        continue;
-                    }
-                    foreach($transaction['parts'] as $a_part) {
-                        $transactionArray = Array();
-                        $transactionArray['unique_id'] = $transaction['affiliatemarketing_id'] . '-' . $a_part['id'];
-                        $transactionArray['merchantId'] = $transaction['program_id'];
-                        $transactionArray['merchantName'] = $transaction['program_name'];
-                        $transactionDate = new \DateTime($a_part['date']);
-                        $transactionArray['date'] = $transactionDate->format("Y-m-d H:i:s");
-                        $transactionDateClick = new \DateTime($a_part['date_click']);
-                        $transactionArray['click_date'] = $transactionDateClick->format("Y-m-d H:i:s");
-                        $transactionDateUpdate = new \DateTime($a_part['last_modified']);
-                        $transactionArray['update_date'] = $transactionDateUpdate->format("Y-m-d H:i:s");
+			while (!$finish) {
+				$url = "https://services.daisycon.com:443/publishers/$publisherId/transactions?page=$page&per_page=$pageSize&start=" . \urlencode($dStartDate->format("Y-m-d H:i:s")) . "&end=" . \urlencode($dEndDate->format("Y-m-d H:i:s"));
+				// initialize curl resource
+				$ch = curl_init();
+				// set the http request authentication headers
+				$headers = array('Authorization: Basic ' . base64_encode($user . ':' . $password));
+				// set curl options
+				curl_setopt($ch, CURLOPT_URL, $url);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+				// execute curl
+				$response = curl_exec($ch);
+				$transactionList = json_decode($response, true);
 
-                        $transactionArray['custom_id'] = $a_part['subid'];
-                        if ($a_part['status'] == 'approved') {
-                            $transactionArray['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-                        } elseif ($a_part['status'] == 'pending' || $a_part['status'] == 'potential' || $a_part['status'] == 'open') {
-                            $transactionArray['status'] = \Oara\Utilities::STATUS_PENDING;
-                        } elseif ($a_part['status'] == 'disapproved' || $a_part['status'] == 'incasso') {
-                            $transactionArray['status'] = \Oara\Utilities::STATUS_DECLINED;
-                        } else {
-                            throw new \Exception("Unexpected transaction status {$a_part['status']}");
-                        }
-                        $transactionArray['currency'] = 'EUR';  // Default value
-                        $transactionArray['amount'] = \Oara\Utilities::parseDouble($a_part['revenue']);
-                        $transactionArray['commission'] = \Oara\Utilities::parseDouble($a_part['commission']);
-                        $transactionArray['IP'] = $transaction['anonymous_ip'];
+				foreach ($transactionList as $transaction) {
+					$merchantId = $transaction['program_id'];
+					if (is_array($merchantList) && count($merchantList) > 0 && !isset($merchantIdList[$merchantId])) {
+						// Skip unwanted merchants (empty merchant array means "all" merchants)
+						continue;
+					}
+					if (!isset($transaction['parts']) || count($transaction['parts']) == 0) {
+						continue;
+					}
+					foreach ($transaction['parts'] as $a_part) {
+						$transactionArray = Array();
+						$transactionArray['unique_id'] = $transaction['affiliatemarketing_id'] . '-' . $a_part['id'];
+						$transactionArray['merchantId'] = $transaction['program_id'];
+						$transactionArray['merchantName'] = $transaction['program_name'];
+						$transactionDate = new \DateTime($a_part['date']);
+						$transactionArray['date'] = $transactionDate->format("Y-m-d H:i:s");
+						$transactionDateClick = new \DateTime($a_part['date_click']);
+						$transactionArray['click_date'] = $transactionDateClick->format("Y-m-d H:i:s");
+						$transactionDateUpdate = new \DateTime($a_part['last_modified']);
+						$transactionArray['update_date'] = $transactionDateUpdate->format("Y-m-d H:i:s");
 
-                        $totalTransactions[] = $transactionArray;
-                    }
-                }
-                if (\count($transactionList) != $pageSize) {
-                    $finish = true;
-                }
-                $page++;
-            }
-        }
+						$transactionArray['custom_id'] = $a_part['subid'];
+						if ($a_part['status'] == 'approved') {
+							$transactionArray['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+						} elseif ($a_part['status'] == 'pending' || $a_part['status'] == 'potential' || $a_part['status'] == 'open') {
+							$transactionArray['status'] = \Oara\Utilities::STATUS_PENDING;
+						} elseif ($a_part['status'] == 'disapproved' || $a_part['status'] == 'incasso') {
+							$transactionArray['status'] = \Oara\Utilities::STATUS_DECLINED;
+						} else {
+							throw new \Exception("Unexpected transaction status {$a_part['status']}");
+						}
+						$transactionArray['currency'] = 'EUR';  // Default value
+						$transactionArray['amount'] = \Oara\Utilities::parseDouble($a_part['revenue']);
+						$transactionArray['commission'] = \Oara\Utilities::parseDouble($a_part['commission']);
+						$transactionArray['IP'] = $transaction['anonymous_ip'];
 
-        return $totalTransactions;
-    }
+						$totalTransactions[] = $transactionArray;
+					}
+				}
+				if (count($transactionList) != $pageSize) {
+					$finish = true;
+				}
+				$page++;
+			}
+		}
 
-    /**
-     * @return array
-     */
-    public function getVouchers() {
+		return $totalTransactions;
+	}
 
-        $a_vouchers = array();
+	/**
+	 * See: https://developers.daisycon.com/api/resources/publisher-resources/
+	 * @return array
+	 */
+	public function getVouchers()
+	{
 
-        $user = $this->_credentials['user'];
-        $password = $this->_credentials['password'];
-        $id_site = $this->_credentials['idSite'];      // publisher id to retrieve (empty = all publishers)
+		$a_vouchers = array();
 
-        foreach ($this->_publisherId as $publisherId) {
-            if (!empty($id_site) && $publisherId != $id_site) {
-                // Skip unwanted publisher accounts
-                continue;
-            }
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$id_site = $this->_credentials['idSite'];      // publisher id to retrieve (empty = all publishers)
 
-            $page = 1;
-            $pageSize = 100;
-            $finish = false;
+		foreach ($this->_publisherId as $publisherId) {
+			if (!empty($id_site) && $publisherId != $id_site) {
+				// Skip unwanted publisher accounts
+				continue;
+			}
+			$media_id = '';
+			if (isset($_ENV['DAISYCON_MEDIA_ID'])) {
+				//Returns programs this media is subscribed to
+				$media_id = '&media_id=' . $_ENV['DAISYCON_MEDIA_ID'];
+			}
 
-            while (!$finish) {
-                $url = "https://services.daisycon.com:443/publishers/$publisherId/material/promotioncodes?page=$page&per_page=$pageSize";
-                // initialize curl resource
-                $ch = \curl_init();
-                // set the http request authentication headers
-                $headers = array('Authorization: Basic ' . \base64_encode($user . ':' . $password));
-                // set curl options
-                \curl_setopt($ch, CURLOPT_URL, $url);
-                \curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-                \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                // execute curl
-                $response = \curl_exec($ch);
-                $vouchers_list = \json_decode($response, true);
-                foreach ($vouchers_list as $voucher) {
-                    $a_vouchers[] = $voucher;
-                }
-                if (\count($vouchers_list) != $pageSize) {
-                    $finish = true;
-                }
-                $page++;
-            }
-            return $a_vouchers;
-        }
-    }
+			$page = 1;
+			$pageSize = 100;
+			$finish = false;
+
+			while (!$finish) {
+				$url = 'https://services.daisycon.com:443/publishers/' . $publisherId . '/material/promotioncodes?page=' . $page . '&per_page=' . $pageSize . $media_id;
+				// initialize curl resource
+				$ch = curl_init();
+				// set the http request authentication headers
+				$headers = array('Authorization: Basic ' . base64_encode($user . ':' . $password));
+				// set curl options
+				curl_setopt($ch, CURLOPT_URL, $url);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+				// execute curl
+				$response = curl_exec($ch);
+				$vouchers_list = json_decode($response, true);
+				foreach ($vouchers_list as $voucher) {
+					$a_vouchers[] = $voucher;
+				}
+				if (count($vouchers_list) != $pageSize) {
+					$finish = true;
+				}
+				$page++;
+			}
+			return $a_vouchers;
+		}
+	}
 
 }

--- a/Oara/Network/Publisher/Digidip.php
+++ b/Oara/Network/Publisher/Digidip.php
@@ -244,7 +244,7 @@ class Digidip extends \Oara\Network
 	    $transaction['merchantId'] = $transactionJson['merchant']['id'];
 	    $transaction['merchantName'] = $transactionJson['merchant']['name'];
 	    $transaction['date'] = $transactionJson['date']['iso8601'];
-	    $transaction['click_date'] = $transactionJson['click']['date']['iso8601'];
+	    $transaction['click_date'] = $transactionJson['click']['date']['iso8601'] ?? null;
 	    $transaction['update_date'] = $transactionJson['last_modified_date']['iso8601'] ?? null;
 	    $transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson['price']['amount']);
 	    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson['commission']['amount']);

--- a/Oara/Network/Publisher/Digidip.php
+++ b/Oara/Network/Publisher/Digidip.php
@@ -1,0 +1,278 @@
+<?php
+namespace Oara\Network\Publisher;
+    /**
+     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+     *
+     * Copyright (C) 2016  Fubra Limited
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Affero General Public License as published by
+     * the Free Software Foundation, either version 3 of the License, or any later version.
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Affero General Public License for more details.
+     * You should have received a copy of the GNU Affero General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+     * Contact
+     * ------------
+     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+     **/
+
+class Digidip extends \Oara\Network
+{
+    private $_credentials = null;
+
+
+    /**
+     * @param $credentials
+     * @throws Exception
+     */
+    public function login($credentials)
+    {
+	    $this->_credentials = $credentials;
+
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getNeededCredentials()
+    {
+        $credentials = array();
+
+        $parameter = array();
+        $parameter["description"] = "User Log in";
+        $parameter["required"] = true;
+        $parameter["name"] = "User";
+        $credentials["user"] = $parameter;
+
+        $parameter = array();
+        $parameter["description"] = "Password to Log in";
+        $parameter["required"] = true;
+        $parameter["name"] = "Password";
+        $credentials[] = $parameter;
+
+        return $credentials;
+    }
+
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = true;
+		return $connection;
+	}
+
+
+
+   /**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+    {
+	    /**
+	     * https://digidip.net/api/documentation
+	     * Retrieve a list of transactions (contains extended data). Max request time frame is 7 days
+	     * The values for dates should be in in unix timestamp
+	     * Returns the result in the JSON format
+	     */
+	    $user = $this->_credentials['user'];
+	    $password = $this->_credentials['password'];
+	    $id_site = $this->_credentials['idSite'];
+    	$totalTransactions = array();
+	    $page = 0;
+	    $loop = true;
+
+	    if (empty($dStartDate) || empty($dEndDate)){
+		    throw new \Exception("[Oara][Network][Publisher][Digidip][getTransactionList] Date required. Max request time frame is 7 days");
+	    }
+	    $diff_in_days = $dEndDate->diffInDays($dStartDate);
+	    if ($diff_in_days > 7){
+		    throw new \Exception("[Oara][Network][Publisher][Digidip][getTransactionList] Check date. Max request time frame is 7 days");
+	    }
+
+	    while ($loop){
+
+	    	$transactions = "https://api.digidip.net/detailed-transactions";
+		    $params = array(
+			    new \Oara\Curl\Parameter('project_id',  $id_site),
+			    new \Oara\Curl\Parameter('timestamp_start',  $dStartDate->timestamp),
+			    new \Oara\Curl\Parameter('timestamp_end', $dEndDate->timestamp),
+			    new \Oara\Curl\Parameter('page', $page),
+			);
+
+		    $p = array();
+		    foreach ($params as $parameter) {
+			    $p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+		    }
+		    $get_params = implode('&', $p);
+
+		    $ch = curl_init();
+		    curl_setopt($ch, CURLOPT_URL, $transactions . '?' . $get_params);
+		    curl_setopt($ch, CURLOPT_POST, false);
+		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+		    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
+
+		    $curl_results = curl_exec($ch);
+		    curl_close($ch);
+		    $transactionsList = json_decode($curl_results, true);
+
+		    if (isset($transactionsList['data'])){
+			    if (count($transactionsList["data"]) == 0) {
+				    $loop = false;
+				    break;
+			    }
+		    	foreach ($transactionsList['data'] as $transactionJson) {
+
+				    $a_transaction = self::createTransactionArray($transactionJson);
+
+				    $totalTransactions[] = $a_transaction;
+			    }
+			    $page = (int)(1 + $page);
+		    }
+		    else{
+			    if (isset($transactionsList['errors']) && isset($transactionsList['message'])){
+				    throw new \Exception("[Oara][Network][Publisher][Digidip][getTransactionList] " . $transactionsList['message']);
+			    }
+			    $loop = false;
+		    }
+		}
+	    return $totalTransactions;
+
+    }
+
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 */
+	public function getTransactions($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$id_site = $this->_credentials['idSite'];
+		$totalTransactions = array();
+		$limit = 1000;
+		$page = 0;
+		$loop = true;
+
+		while ($loop){
+			/**
+			 * https://digidip.net/api/documentation
+			 * The values for dates should be in in unix timestamp
+			 * Returns the result in the JSON format
+			 */
+			$transactions = "https://api.digidip.net/transactions";
+			$params = array(
+				new \Oara\Curl\Parameter('project_id',  $id_site),
+				new \Oara\Curl\Parameter('timestamp_start',  $dStartDate->timestamp),
+				new \Oara\Curl\Parameter('timestamp_end', $dEndDate->timestamp),
+				new \Oara\Curl\Parameter('page', $page),
+			);
+
+			$p = array();
+			foreach ($params as $parameter) {
+				$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+			}
+			$get_params = implode('&', $p);
+
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $transactions . '?' . $get_params);
+			curl_setopt($ch, CURLOPT_POST, false);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
+
+			$curl_results = curl_exec($ch);
+			curl_close($ch);
+			$transactionsList = json_decode($curl_results, true);
+
+			foreach ($transactionsList['data'] as $transactionJson) {
+
+				$transaction_id = $transactionJson["transaction_id"];
+				$transaction_href = $transactionJson["_links"][0]["href"];
+
+				$transaction = self::getTransaction($transaction_id);
+
+				$totalTransactions[] = $transaction;
+			}
+			if (count($transactionsList["data"]) <= $limit) {
+				$loop = false;
+			}
+			$page = (int)(1 + $page);
+		}
+		return $totalTransactions;
+
+	}
+
+    public function getTransaction($transaction_id){
+
+	    $user = $this->_credentials['user'];
+	    $password = $this->_credentials['password'];
+
+	    $transaction = "https://api.digidip.net/transactions/" . $transaction_id;
+
+	    $ch = curl_init();
+	    curl_setopt($ch, CURLOPT_URL, $transaction);
+	    curl_setopt($ch, CURLOPT_POST, false);
+	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+	    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
+
+	    $curl_results = curl_exec($ch);
+	    curl_close($ch);
+	    $transactionsList = json_decode($curl_results, true);
+
+	    foreach ($transactionsList['data'] as $transactionJson) {
+
+			return self::createTransactionArray($transactionJson);
+
+	    }
+    }
+
+    public function createTransactionArray($transactionJson){
+
+	    $transaction = Array();
+	    $transaction['unique_id'] = $transactionJson['id'];
+	    $transaction['merchantId'] = $transactionJson['merchant']['id'];
+	    $transaction['merchantName'] = $transactionJson['merchant']['name'];
+	    $transaction['date'] = $transactionJson['date']['iso8601'];
+	    $transaction['click_date'] = $transactionJson['click']['date']['iso8601'];
+	    $transaction['update_date'] = $transactionJson['last_modified_date']['iso8601'] ?? null;
+	    $transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson['price']['amount']);
+	    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson['commission']['amount']);
+	    $transaction['currency'] = $transactionJson['commission']['currency'];
+	    $transaction['custom_id'] = $transactionJson['click']['custom_subid']['content'] ?? null;
+	    $transaction['IP'] = null;
+	    $transaction['action'] = null;
+
+	    switch ($transactionJson["status"]){
+		    case 'pending':
+		    case 'added':
+		    case 'received':
+			    $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+			    break;
+		    case 'denied':
+		        $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+			    break;
+		    case 'validated':
+		    case 'payment processing':
+		    case 'paid':
+			    $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+			    break;
+	    }
+	    return $transaction;
+    }
+
+
+
+
+
+}

--- a/Oara/Network/Publisher/Digidip.php
+++ b/Oara/Network/Publisher/Digidip.php
@@ -124,8 +124,8 @@ class Digidip extends \Oara\Network
 					$transactions = "https://api.digidip.net/detailed-transactions";
 					$params = array(
 						new \Oara\Curl\Parameter('project_id',  $id_site),
-						new \Oara\Curl\Parameter('timestamp_start',  $dStartDate->timestamp),
-						new \Oara\Curl\Parameter('timestamp_end', $dEndDate->timestamp),
+						new \Oara\Curl\Parameter('timestamp_start',  $dStartDate->getTimestamp()),
+						new \Oara\Curl\Parameter('timestamp_end', $dEndDate->getTimestamp()),
 						new \Oara\Curl\Parameter('page', $page),
 					);
 

--- a/Oara/Network/Publisher/Digidip.php
+++ b/Oara/Network/Publisher/Digidip.php
@@ -1,62 +1,62 @@
 <?php
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
 
 class Digidip extends \Oara\Network
 {
-    private $_credentials = null;
+	private $_credentials = null;
 
 
-    /**
-     * @param $credentials
-     * @throws Exception
-     */
-    public function login($credentials)
-    {
-	    $this->_credentials = $credentials;
+	/**
+	 * @param $credentials
+	 * @throws Exception
+	 */
+	public function login($credentials)
+	{
+		$this->_credentials = $credentials;
 
-    }
+	}
 
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials[] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials[] = $parameter;
 
-        return $credentials;
-    }
+		return $credentials;
+	}
 
 	/**
 	 * @return bool
@@ -69,85 +69,111 @@ class Digidip extends \Oara\Network
 
 
 
-   /**
+	/**
 	 * @param null $merchantList
 	 * @param \DateTime|null $dStartDate
 	 * @param \DateTime|null $dEndDate
 	 * @return array
 	 * @throws \Exception
 	 */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-	    /**
-	     * https://digidip.net/api/documentation
-	     * Retrieve a list of transactions (contains extended data). Max request time frame is 7 days
-	     * The values for dates should be in in unix timestamp
-	     * Returns the result in the JSON format
-	     */
-	    $user = $this->_credentials['user'];
-	    $password = $this->_credentials['password'];
-	    $id_site = $this->_credentials['idSite'];
-    	$totalTransactions = array();
-	    $page = 0;
-	    $loop = true;
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		/**
+		 * https://digidip.net/api/documentation
+		 * Retrieve a list of transactions (contains extended data). Max request time frame is 7 days
+		 * The values for dates should be in in unix timestamp
+		 * Returns the result in the JSON format
+		 */
+		$totalTransactions = array();
+		try{
+			$user = $this->_credentials['user'];
+			$password = $this->_credentials['password'];
+			$id_site = $this->_credentials['idSite'];
+			$page = 0;
+			$loop = true;
+			$a_dates = array();
 
-	    if (empty($dStartDate) || empty($dEndDate)){
-		    throw new \Exception("[Oara][Network][Publisher][Digidip][getTransactionList] Date required. Max request time frame is 7 days");
-	    }
-	    $diff_in_days = $dEndDate->diffInDays($dStartDate);
-	    if ($diff_in_days > 7){
-		    throw new \Exception("[Oara][Network][Publisher][Digidip][getTransactionList] Check date. Max request time frame is 7 days");
-	    }
+			if (empty($dStartDate) || empty($dEndDate)){
+				throw new \Exception("[Digidip][getTransactionList] Date required. Max request time frame is 7 days");
+			}
+			$interval = $dStartDate->diff($dEndDate);
+			$interval_in_days = $interval->days;
+			if ($interval_in_days > 6){
+				//Create groups of dates, Get transactions grouping by dates. Max request time frame is 7 days.
+				$auxStartDate = clone $dStartDate;
+				$auxDate = $auxStartDate->modify("+ 6 days");
+				while ($dEndDate > $auxDate){
+					$a_dates[] = array($dStartDate, $auxDate);
+					$dStartDate = clone $auxDate;
+					$auxStartDate = clone $auxDate;
+					$auxDate = $auxStartDate->modify("+ 6 days");
+					if ($auxDate > $dEndDate){
+						$auxDate = $dEndDate;
+						$a_dates[] = array($dStartDate, $auxDate);
+					}
+				}
+			}
+			else{
+				$a_dates[] = array($dStartDate, $dEndDate);
+			}
+			foreach ($a_dates as $dates){
+				$dStartDate = $dates[0];
+				$dEndDate = $dates[1];
 
-	    while ($loop){
+				while ($loop){
 
-	    	$transactions = "https://api.digidip.net/detailed-transactions";
-		    $params = array(
-			    new \Oara\Curl\Parameter('project_id',  $id_site),
-			    new \Oara\Curl\Parameter('timestamp_start',  $dStartDate->timestamp),
-			    new \Oara\Curl\Parameter('timestamp_end', $dEndDate->timestamp),
-			    new \Oara\Curl\Parameter('page', $page),
-			);
+					$transactions = "https://api.digidip.net/detailed-transactions";
+					$params = array(
+						new \Oara\Curl\Parameter('project_id',  $id_site),
+						new \Oara\Curl\Parameter('timestamp_start',  $dStartDate->timestamp),
+						new \Oara\Curl\Parameter('timestamp_end', $dEndDate->timestamp),
+						new \Oara\Curl\Parameter('page', $page),
+					);
 
-		    $p = array();
-		    foreach ($params as $parameter) {
-			    $p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
-		    }
-		    $get_params = implode('&', $p);
+					$p = array();
+					foreach ($params as $parameter) {
+						$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+					}
+					$get_params = implode('&', $p);
 
-		    $ch = curl_init();
-		    curl_setopt($ch, CURLOPT_URL, $transactions . '?' . $get_params);
-		    curl_setopt($ch, CURLOPT_POST, false);
-		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-		    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
+					$ch = curl_init();
+					curl_setopt($ch, CURLOPT_URL, $transactions . '?' . $get_params);
+					curl_setopt($ch, CURLOPT_POST, false);
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+					curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
 
-		    $curl_results = curl_exec($ch);
-		    curl_close($ch);
-		    $transactionsList = json_decode($curl_results, true);
+					$curl_results = curl_exec($ch);
+					curl_close($ch);
+					$transactionsList = json_decode($curl_results, true);
 
-		    if (isset($transactionsList['data'])){
-			    if (count($transactionsList["data"]) == 0) {
-				    $loop = false;
-				    break;
-			    }
-		    	foreach ($transactionsList['data'] as $transactionJson) {
+					if (isset($transactionsList['data'])){
+						if (count($transactionsList["data"]) == 0) {
+							$loop = false;
+							break;
+						}
+						foreach ($transactionsList['data'] as $transactionJson) {
 
-				    $a_transaction = self::createTransactionArray($transactionJson);
-
-				    $totalTransactions[] = $a_transaction;
-			    }
-			    $page = (int)(1 + $page);
-		    }
-		    else{
-			    if (isset($transactionsList['errors']) && isset($transactionsList['message'])){
-				    throw new \Exception("[Oara][Network][Publisher][Digidip][getTransactionList] " . $transactionsList['message']);
-			    }
-			    $loop = false;
-		    }
+							$a_transaction = self::createTransactionArray($transactionJson);
+							$totalTransactions[] = $a_transaction;
+						}
+						$page = (int)(1 + $page);
+					}
+					else{
+						if (isset($transactionsList['errors']) && isset($transactionsList['message'])){
+							throw new \Exception("[Digidip][getTransactionList] " . $transactionsList['message']);
+						}
+						$loop = false;
+					}
+				}
+			}
 		}
-	    return $totalTransactions;
+		catch (\Exception $e){
+			throw new \Exception($e);
+		}
 
-    }
+		return $totalTransactions;
+
+	}
 
 	/**
 	 * @param null $merchantList
@@ -213,63 +239,63 @@ class Digidip extends \Oara\Network
 
 	}
 
-    public function getTransaction($transaction_id){
+	public function getTransaction($transaction_id){
 
-	    $user = $this->_credentials['user'];
-	    $password = $this->_credentials['password'];
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
 
-	    $transaction = "https://api.digidip.net/transactions/" . $transaction_id;
+		$transaction = "https://api.digidip.net/transactions/" . $transaction_id;
 
-	    $ch = curl_init();
-	    curl_setopt($ch, CURLOPT_URL, $transaction);
-	    curl_setopt($ch, CURLOPT_POST, false);
-	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-	    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $transaction);
+		curl_setopt($ch, CURLOPT_POST, false);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . \base64_encode($user . ':' . $password), "Accept: application/json"));
 
-	    $curl_results = curl_exec($ch);
-	    curl_close($ch);
-	    $transactionsList = json_decode($curl_results, true);
+		$curl_results = curl_exec($ch);
+		curl_close($ch);
+		$transactionsList = json_decode($curl_results, true);
 
-	    foreach ($transactionsList['data'] as $transactionJson) {
+		foreach ($transactionsList['data'] as $transactionJson) {
 
 			return self::createTransactionArray($transactionJson);
 
-	    }
-    }
+		}
+	}
 
-    public function createTransactionArray($transactionJson){
+	public function createTransactionArray($transactionJson){
 
-	    $transaction = Array();
-	    $transaction['unique_id'] = $transactionJson['id'];
-	    $transaction['merchantId'] = $transactionJson['merchant']['id'];
-	    $transaction['merchantName'] = $transactionJson['merchant']['name'];
-	    $transaction['date'] = $transactionJson['date']['iso8601'];
-	    $transaction['click_date'] = $transactionJson['click']['date']['iso8601'] ?? null;
-	    $transaction['update_date'] = $transactionJson['last_modified_date']['iso8601'] ?? null;
-	    $transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson['price']['amount']);
-	    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson['commission']['amount']);
-	    $transaction['currency'] = $transactionJson['commission']['currency'];
-	    $transaction['custom_id'] = $transactionJson['click']['custom_subid']['content'] ?? null;
-	    $transaction['IP'] = null;
-	    $transaction['action'] = null;
+		$transaction = Array();
+		$transaction['unique_id'] = $transactionJson['id'];
+		$transaction['merchantId'] = $transactionJson['merchant']['id'];
+		$transaction['merchantName'] = $transactionJson['merchant']['name'];
+		$transaction['date'] = $transactionJson['date']['iso8601'];
+		$transaction['click_date'] = $transactionJson['click']['date']['iso8601'] ?? null;
+		$transaction['update_date'] = $transactionJson['last_modified_date']['iso8601'] ?? null;
+		$transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson['price']['amount']);
+		$transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson['commission']['amount']);
+		$transaction['currency'] = $transactionJson['commission']['currency'];
+		$transaction['custom_id'] = $transactionJson['click']['custom_subid']['content'] ?? null;
+		$transaction['IP'] = null;
+		$transaction['action'] = null;
 
-	    switch ($transactionJson["status"]){
-		    case 'pending':
-		    case 'added':
-		    case 'received':
-			    $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-			    break;
-		    case 'denied':
-		        $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-			    break;
-		    case 'validated':
-		    case 'payment processing':
-		    case 'paid':
-			    $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-			    break;
-	    }
-	    return $transaction;
-    }
+		switch ($transactionJson["status"]){
+			case 'pending':
+			case 'added':
+			case 'received':
+				$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+				break;
+			case 'denied':
+				$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+				break;
+			case 'validated':
+			case 'payment processing':
+			case 'paid':
+				$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+				break;
+		}
+		return $transaction;
+	}
 
 
 

--- a/Oara/Network/Publisher/Ebay.php
+++ b/Oara/Network/Publisher/Ebay.php
@@ -1,24 +1,26 @@
 <?php
+
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+
 /**
  * Export Class
  *
@@ -30,129 +32,156 @@ namespace Oara\Network\Publisher;
  */
 class Ebay extends \Oara\Network
 {
-    protected $_client = null;
-    protected $_sitesAllowed = array();
+	protected $_client = null;
+	protected $_sitesAllowed = array();
 
-    /**
-     * @param $credentials
-     */
-    public function login($credentials)
-    {
-        $this->_credentials = $credentials;
-        $this->_client = new \Oara\Curl\Access($credentials);
+	/**
+	 * @param $credentials
+	 */
+	public function login($credentials)
+	{
+		$this->_credentials = $credentials;
+	}
 
-        $valuesLogin = array(
-            new \Oara\Curl\Parameter('login_username', $this->_credentials['user']),
-            new \Oara\Curl\Parameter('login_password', $this->_credentials['password']),
-            new \Oara\Curl\Parameter('submit_btn', 'GO'),
-            new \Oara\Curl\Parameter('hubpage', 'y')
-        );
-        $loginUrl = 'https://ebaypartnernetwork.com/PublisherLogin?hubpage=y&lang=en-US?';
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
-        $this->_client->post($urls);
-    }
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials["password"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
+		return $credentials;
+	}
 
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials["password"] = $parameter;
+	/**
+	 * @param string $idSite
+	 */
+	public function addAllowedSite(string $idSite)
+	{
+		$this->_sitesAllowed[] = $idSite;
+	}
 
-        return $credentials;
-    }
 
-    /**
-     * @return bool
-     */
-    public function checkConnection()
-    {
-        //If not login properly the construct launch an exception
-        $connection = true;
-        $yesterday = new \DateTime();
-        $yesterday->sub(new \DateInterval('P2D'));
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = true;
+		return $connection;
+	}
 
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request("https://publisher.ebaypartnernetwork.com/PublisherReportsTx?pt=2&start_date={$yesterday->format("n/j/Y")}&end_date={$yesterday->format("n/j/Y")}&user_name={$this->_credentials['user']}&user_password={$this->_credentials['password']}&advIdProgIdCombo=&tx_fmt=2&submit_tx=Download", array());
-        $exportReport = $this->_client->get($urls);
+	/**
+	 * @return array
+	 */
+	public function getMerchantList()
+	{
+		$merchants = array();
 
-        if (\preg_match("/DOCTYPE html PUBLIC/", $exportReport[0])) {
-            $connection = false;
-        }
-        return $connection;
-    }
+		$obj = array();
+		$obj['cid'] = "1";
+		$obj['name'] = "Ebay";
+		$obj['url'] = "https://partnernetwork.ebay.com/";
+		$merchants[] = $obj;
 
-    /**
-     * @return array
-     */
-    public function getMerchantList()
-    {
-        $merchants = array();
+		return $merchants;
+	}
 
-        $obj = array();
-        $obj['cid'] = "1";
-        $obj['name'] = "Ebay";
-        $obj['url'] = "https://publisher.ebaypartnernetwork.com";
-        $merchants[] = $obj;
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 * See: https://partnerhelp.ebay.com/helpcenter/knowledgebase/Transaction-Detail-Report-Changes-and-Reporting-API-Migration-Guidelines/United%20States%20(EN)
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		//https://<Account_SID>:<Auth_Token>@api.partner.ebay.com/Mediapartners/<Account_SID>/Reports/ebay_partner_transaction_detail.json?STATUS=ALL&START_DATE=<YYYY-MM-DD>&END_DATE=<YYYY-MM-DD>
+		$transactions = "https://{$this->_credentials['user']}:{$this->_credentials['password']}@api.partner.ebay.com/Mediapartners/{$this->_credentials['user']}/Reports/ebay_partner_transaction_detail.json";
+		$params = array(
+			new \Oara\Curl\Parameter('CHECKOUT_SITE', !empty($this->_sitesAllowed) ? implode(',', $this->_sitesAllowed) : '0'), //0 to return all OR Define 1 value from accepted values Accepted Values: US, UK, CA, DE, IT, FR, AU, AT, BE, CH, NL, ES, IE
+			new \Oara\Curl\Parameter('STATUS', 'ALL'), //Approved, Pending, OR All
+			new \Oara\Curl\Parameter('START_DATE', $dStartDate->format('Y-m-d')), //YYYY-MM-DD
+			new \Oara\Curl\Parameter('END_DATE', $dEndDate->format('Y-m-d')), //YYYY-MM-DD
+		);
 
-        return $merchants;
-    }
+		$p = array();
+		foreach ($params as $parameter) {
+			$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+		}
+		$get_params = implode('&', $p);
 
-    /**
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-        $totalTransactions = array();
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request("https://publisher.ebaypartnernetwork.com/PublisherReportsTx?pt=2&start_date={$dStartDate->format("n/j/Y")}&end_date={$dEndDate->format("n/j/Y")}&user_name={$this->_credentials['user']}&user_password={$this->_credentials['password']}&advIdProgIdCombo=&tx_fmt=3&submit_tx=Download", array());
-        $exportData = array();
-        try {
-            $exportReport = $this->_client->get($urls, 'content', 5);
-            $exportData = \str_getcsv($exportReport[0], "\n");
-        } catch (\Exception $e) {
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $transactions . '?' . $get_params);
+		curl_setopt($ch, CURLOPT_POST, false);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 
-        }
-        $num = \count($exportData);
-        for ($i = 1; $i < $num; $i++) {
-            $transactionExportArray = \str_getcsv($exportData[$i], "\t");
+		$curl_results = curl_exec($ch);
+		$matches = preg_match('/<title>(.*?)<\/title>/', $curl_results, $matches);
+		if (!empty($matches)) {
+			throw new \Exception('[Ebay][getTransactionList][Exception] ' . $matches);
+		}
+		curl_close($ch);
+		$transactionsList = json_decode($curl_results, true);
 
-            if ($transactionExportArray[2] == "Winning Bid (Revenue)" && (empty($this->_sitesAllowed) || \in_array($transactionExportArray[5], $this->_sitesAllowed))) {
+		if (isset($transactionsList['Status']) && $transactionsList['Status'] == 'ERROR' && isset($transactionsList['Message'])) {
+			throw new \Exception('[Ebay][getTransactionList][Exception] ' . $transactionsList['Message']);
+		}
 
-                $transaction = Array();
-                $transaction['merchantId'] = 1;
-                $transactionDate = \DateTime::createFromFormat("Y-m-d", $transactionExportArray[1]);
-                $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
-                unset($transactionDate);
-                if ($transactionExportArray[10] != null) {
-                    $transaction['custom_id'] = $transactionExportArray[10];
-                }
+		foreach ($transactionsList['Records'] as $a_transaction) {
+			if (($a_transaction['EventName'] == "Sale" || $a_transaction['EventName'] == "Winning Bid (Revenue)") && (empty($this->_sitesAllowed) || \in_array($a_transaction['CheckoutSite'], $this->_sitesAllowed))) {
+				$transaction = Array();
+				$transaction['merchantId'] = 0;
+				$transaction['merchantName'] = '';
+				$transaction['unique_id'] = !empty($a_transaction['EbayCheckoutTransactionId']) ? $a_transaction['EbayCheckoutTransactionId'] : $a_transaction['EpnTransactionId'];
+				if (!empty($a_transaction['EpnTransactionId']) && !empty($a_transaction['EbayCheckoutTransactionId']) && ($a_transaction['EbayCheckoutTransactionId'] != $a_transaction['EpnTransactionId'])){
+					echo '[Ebay][getTransactionList][Unique Transaction ID] difference between EbayCheckoutTransactionId and EpnTransactionId ' . $a_transaction['EbayCheckoutTransactionId'];
+				}
 
-                $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+				$transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:sO", $a_transaction['EventDate'], new \DateTimeZone('America/Denver'));
+				$transactionDate->setTimezone(new \DateTimeZone('Europe/Rome'));
+				$transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
 
-                $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[3]);
-                $transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[20]);
-                $totalTransactions[] = $transaction;
-            }
-        }
-        return $totalTransactions;
-    }
+				$updateDate = \DateTime::createFromFormat("Y-m-d\TH:i:sO", $a_transaction['UpdateDate'], new \DateTimeZone('America/Denver'));
+				$updateDate->setTimezone(new \DateTimeZone('Europe/Rome'));
+				$transaction['update_date'] = $updateDate->format("Y-m-d H:i:s");
+				if (isset($a_transaction['CustomId']) && !empty($a_transaction['CustomId'])) {
+					$transaction['custom_id'] = $a_transaction['CustomId'];
+				}
+				$clickDate = \DateTime::createFromFormat("Y-m-d\TH:i:sO", $a_transaction['ClickTimestamp'], new \DateTimeZone('America/Denver'));
+				$clickDate->setTimezone(new \DateTimeZone('Europe/Rome'));
+				$transaction['click_date'] = $clickDate->format("Y-m-d H:i:s");
+				$transaction['amount'] = (float) !empty($a_transaction['DeltaSales']) ? $a_transaction['DeltaSales'] : $a_transaction['Sales'];
+				$transaction['commission'] = (float) !empty($a_transaction['DeltaEarnings']) ? $a_transaction['DeltaEarnings'] : $a_transaction['Earnings'];
+				if ($a_transaction['Status'] == 'Approved') {
+					$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+				} elseif ($a_transaction['Status'] == 'Pending') {
+					$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+				} elseif ($a_transaction['Status'] == 'Reversed') {
+					$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+				} else {
+					$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+					echo '[Ebay][getTransactionList] Transaction status unexpected ' . $a_transaction['Status'];
+				}
+
+				$totalTransactions[] = $transaction;
+			}
+		}
+
+		return $totalTransactions;
+	}
 
 }

--- a/Oara/Network/Publisher/Ebay.php
+++ b/Oara/Network/Publisher/Ebay.php
@@ -109,6 +109,7 @@ class Ebay extends \Oara\Network
 	 */
 	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
 	{
+		$totalTransactions = array();
 		//https://<Account_SID>:<Auth_Token>@api.partner.ebay.com/Mediapartners/<Account_SID>/Reports/ebay_partner_transaction_detail.json?STATUS=ALL&START_DATE=<YYYY-MM-DD>&END_DATE=<YYYY-MM-DD>
 		$transactions = "https://{$this->_credentials['user']}:{$this->_credentials['password']}@api.partner.ebay.com/Mediapartners/{$this->_credentials['user']}/Reports/ebay_partner_transaction_detail.json";
 		$params = array(
@@ -147,7 +148,7 @@ class Ebay extends \Oara\Network
 				$transaction['merchantId'] = 0;
 				$transaction['merchantName'] = '';
 				$transaction['unique_id'] = !empty($a_transaction['EbayCheckoutTransactionId']) ? $a_transaction['EbayCheckoutTransactionId'] : $a_transaction['EpnTransactionId'];
-				if (!empty($a_transaction['EpnTransactionId']) && !empty($a_transaction['EbayCheckoutTransactionId']) && ($a_transaction['EbayCheckoutTransactionId'] != $a_transaction['EpnTransactionId'])){
+				if (!empty($a_transaction['EpnTransactionId']) && !empty($a_transaction['EbayCheckoutTransactionId']) && ($a_transaction['EbayCheckoutTransactionId'] != $a_transaction['EpnTransactionId'])) {
 					echo '[Ebay][getTransactionList][Unique Transaction ID] difference between EbayCheckoutTransactionId and EpnTransactionId ' . $a_transaction['EbayCheckoutTransactionId'];
 				}
 
@@ -164,8 +165,8 @@ class Ebay extends \Oara\Network
 				$clickDate = \DateTime::createFromFormat("Y-m-d\TH:i:sO", $a_transaction['ClickTimestamp'], new \DateTimeZone('America/Denver'));
 				$clickDate->setTimezone(new \DateTimeZone('Europe/Rome'));
 				$transaction['click_date'] = $clickDate->format("Y-m-d H:i:s");
-				$transaction['amount'] = (float) !empty($a_transaction['DeltaSales']) ? $a_transaction['DeltaSales'] : $a_transaction['Sales'];
-				$transaction['commission'] = (float) !empty($a_transaction['DeltaEarnings']) ? $a_transaction['DeltaEarnings'] : $a_transaction['Earnings'];
+				$transaction['amount'] = (float)!empty($a_transaction['DeltaSales']) ? $a_transaction['DeltaSales'] : $a_transaction['Sales'];
+				$transaction['commission'] = (float)!empty($a_transaction['DeltaEarnings']) ? $a_transaction['DeltaEarnings'] : $a_transaction['Earnings'];
 				if ($a_transaction['Status'] == 'Approved') {
 					$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
 				} elseif ($a_transaction['Status'] == 'Pending') {

--- a/Oara/Network/Publisher/ImpactRadius.php
+++ b/Oara/Network/Publisher/ImpactRadius.php
@@ -230,8 +230,13 @@ class ImpactRadius extends \Oara\Network
                     $transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->EventDate,0,19));
                     $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
 
-                    $transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->ReferringDate,0,19));
-                    $transaction['date_click'] = $transactionDate->format("Y-m-d H:i:s");
+					if((string)$action->ReferringDate != ''){
+						$transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->ReferringDate,0,19));
+						$transaction['date_click'] = $transactionDate->format("Y-m-d H:i:s");
+					}
+					else{
+						$transaction['date_click'] = $transaction['date'];
+					}
 
                     if ((string)$action->SharedId != '') {
                         $transaction['custom_id'] = (string)$action->SharedId;

--- a/Oara/Network/Publisher/ImpactRadius.php
+++ b/Oara/Network/Publisher/ImpactRadius.php
@@ -1,24 +1,25 @@
 <?php
+
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
 
 /**
  * Export Class
@@ -31,346 +32,375 @@ namespace Oara\Network\Publisher;
  */
 class ImpactRadius extends \Oara\Network
 {
-    private $_credentials = null;
-    private $_accountSid = null;
-    private $_authToken = null;
-    private $_merchant_list = null;
-
-    /**
-     * @param $credentials
-     * @throws Exception
-     * @throws \Exception
-     * @throws \Oara\Curl\Exception
-     */
-    public function login($credentials)
-    {
-        $this->_credentials = $credentials;
-
-        if (isset($this->_credentials['api-sid']) && isset($this->_credentials['api-token'])) {
-            // <slawn> - Allow passing sid+token with credentials
-            $this->_accountSid = $this->_credentials['api-sid'];
-            $this->_authToken = $this->_credentials['api-token'];
-            return;
-        }
-        // Compatibility fallback - try to simulate login to access token
-        $this->_client = new \Oara\Curl\Access($credentials);
-        $user = $this->_credentials['user'];
-        $password = $this->_credentials['password'];
-        $loginUrl = 'https://app.impact.com/secure/login.user';
-
-        $valuesLogin = array(new \Oara\Curl\Parameter('j_username', $user),
-            new \Oara\Curl\Parameter('j_password', $password)
-        );
-
-        // Perform Login
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
-        $this->_client->post($urls);
-
-        // Open Technical Settings page
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('https://app.impact.com/secure/mediapartner/accountSettings/mp-wsapi-flow.ihtml?', array());
-        $apiPageHTML = $this->_client->get($urls);
-
-        // Parse page content
-        $dom = new \DOMDocument();
-        libxml_use_internal_errors(true);
-        $dom->loadHTML($apiPageHTML[0]);
-
-        // Search for API keys
-        $xpath = new \DOMXPath($dom);
-        $contents = $xpath->query("//div[@class='uitkFields']/*");
-        if ($contents->length != 0) {
-            foreach ($contents as $i => $content) {
-                $value = $content->textContent;
-                if ($i == 0) {
-                    $this->_accountSid = str_replace(array("\n", "\t", " "), "", $value);
-                } else if ($i == 1) {
-                    $this->_authToken = str_replace(array("\n", "\t", " "), "", $value);
-                }
-            }
-        }
-    }
-
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
-
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
-
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials["password"] = $parameter;
-
-        return $credentials;
-    }
-
-    /**
-     * @return bool
-     */
-    public function checkConnection()
-    {
-        if (empty($this->_accountSid) || empty($this->_authToken)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * It returns an array with the different merchants
-     * @return array
-     */
-    public function getMerchantList()
-    {
-        if (!is_null($this->_merchant_list) && is_array($this->_merchant_list)) {
-            return $this->_merchant_list;
-        }
-        $this->_merchant_list = Array();
-        if (!$this->checkConnection()) {
-            $this->_merchant_list;
-        }
-        $uri = "https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com/Mediapartners/" . $this->_accountSid . "/Campaigns";
-        $res = \simplexml_load_file($uri);
-        $currentPage = (int)$res->Campaigns->attributes()->page;
-        $pageNumber = (int)$res->Campaigns->attributes()->numpages;
-        while ($currentPage <= $pageNumber) {
-
-            foreach ($res->Campaigns->Campaign as $campaign) {
-                $obj = Array();
-                $obj['cid'] = (int)$campaign->CampaignId;
-                $obj['name'] = (string)$campaign->CampaignName;
-                $obj['url'] = (string)$campaign->CampaignUrl;
-                $obj['status'] = (string)$campaign->ContractStatus;
-                $this->_merchant_list[] = $obj;
-            }
-
-            $currentPage++;
-            $nextPageUri = (string)$res->Campaigns->attributes()->nextpageuri;
-            if ($nextPageUri != null) {
-                $res = \simplexml_load_file("https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com" . $nextPageUri);
-            }
-        }
-        return $this->_merchant_list;
-    }
-
-    /**
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-        $totalTransactions = Array();
-
-        if (!$this->checkConnection()) {
-            return $totalTransactions;
-        }
-
-        //New Interface
-        $uri = "https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com/Mediapartners/" . $this->_accountSid . "/Actions?ActionDateStart=" . $dStartDate->format('Y-m-d\TH:i:s') . "-00:00&ActionDateEnd=" . $dEndDate->format('Y-m-d\TH:i:s') . "-00:00";
-        $res = \simplexml_load_file($uri);
-        if ($res) {
-
-            $currentPage = (int)$res->Actions->attributes()->page;
-            $pageNumber = (int)$res->Actions->attributes()->numpages;
-            while ($currentPage <= $pageNumber) {
-
-                foreach ($res->Actions->Action as $action) {
-
-                    /*
-                     * Example of transaction from API docs
-                      "Id": "3641.3299.182972",
-                      "CampaignId": 3641,
-                      "CampaignName": "Rocket-Powered Products",
-                      "ActionTrackerId": 9026,
-                      "ActionTrackerName": "irt-17721",
-                      "State": "PENDING",
-                      "AdId": 339815,
-                      "Payout": 32252.1922,
-                      "DeltaPayout": 32252.1922,
-                      "IntendedPayout": 32252.1922,
-                      "Amount": 32252.19,
-                      "DeltaAmount": 32252.19,
-                      "IntendedAmount": 32252.19,
-                      "Currency": "USD",
-                      "ReferringDate": "2017-01-11T22:18:42.000Z",
-                      "EventDate": "2017-01-12T19:52:07.000Z",
-                      "CreationDate": "2017-01-16T05:25:15.000Z",
-                      "LockingDate": "2017-02-16T08:00:00.000Z",
-                      "ClearedDate": "2017-02-31T08:00:00.000Z",
-                      "ReferringType": "CLICK_COOKIE",
-                      "ReferringDomain": "www.referring.com",
-                      "PromoCode": "SUMMER_PROMO",
-                      "Oid": "AZ3456-123V",
-                      "CustomerArea": "0",
-                      "CustomerCity": "New York",
-                      "CustomerRegion": "212",
-                      "CustomerCountry": "US",
-                      "SubId1": "custom1",
-                      "SubId2": "custom2",
-                      "SubId3": "custom3",
-                      "SharedId": "custom-shared",
-                      "Uri": "/Mediapartners/IRBcXt64v4pL159338fdubAiqsbdX65535/Actions/3641.3299.182972.json"
-                     */
-                    $transaction = Array();
-                    $transaction['unique_id'] = (string)$action->Id;
-                    $transaction['merchant_id'] = (int)$action->CampaignId;
-                    $transaction['merchant_name'] = (int)$action->CampaignName;
+	private $_credentials = null;
+	private $_accountSid = null;
+	private $_authToken = null;
+	private $_merchant_list = null;
 
 
-                    $transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->EventDate,0,19));
-                    $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
+	/**
+	 * @param $credentials
+	 * @throws Exception
+	 * @throws \Exception
+	 * @throws \Oara\Curl\Exception
+	 */
+	public function login($credentials)
+	{
+		$this->_credentials = $credentials;
 
-                    if((string)$action->ReferringDate != ''){
-                        // <slawn>
-                        $transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->ReferringDate,0,19));
-                        $transaction['date_click'] = $transactionDate->format("Y-m-d H:i:s");
-                    }
-                    else{
-                        $transaction['date_click'] = $transaction['date'];
-                    }
+		if (isset($this->_credentials['api-sid']) && isset($this->_credentials['api-token'])) {
+			// <slawn> - Allow passing sid+token with credentials
+			$this->_accountSid = $this->_credentials['api-sid'];
+			$this->_authToken = $this->_credentials['api-token'];
+			return;
+		}
+		// Compatibility fallback - try to simulate login to access token
+		$this->_client = new \Oara\Curl\Access($credentials);
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$loginUrl = 'https://app.impact.com/secure/login.user';
 
-                    if ((string)$action->SharedId != '') {
-                        $transaction['custom_id'] = (string)$action->SharedId;
-                    }
-                    if ((string)$action->SubId1 != '') {
-                        $transaction['custom_id'] = (string)$action->SubId1;
-                    }
+		$valuesLogin = array(new \Oara\Curl\Parameter('j_username', $user),
+			new \Oara\Curl\Parameter('j_password', $password)
+		);
 
-                    $status = (string)$action->State;
-                    $statusArray[$status] = "";
-                    if ($status == 'APPROVED' || $status == 'DEFAULT') {
-                        $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-                    } else {
-                        if ($status == 'REVERSED' || $status == 'REJECTED') {
-                            $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-                        } else {
-                            $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-                        }
-                    }
+		// Perform Login
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
+		$this->_client->post($urls);
 
-                    $transaction['currency'] = (string)$action->Currency;
-                    $transaction['amount'] = (double)$action->Amount;
-                    $transaction['commission'] = (double)$action->Payout;
-                    $transaction['commission_intended'] = (double)$action->IntendedPayout; // ??
-                    $totalTransactions[] = $transaction;
-                }
+		// Open Technical Settings page
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('https://app.impact.com/secure/mediapartner/accountSettings/mp-wsapi-flow.ihtml?', array());
+		$apiPageHTML = $this->_client->get($urls);
 
-                $currentPage++;
-                $nextPageUri = (string)$res->Actions->attributes()->nextpageuri;
-                if ($nextPageUri != null) {
-                    $res = \simplexml_load_file("https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com" . $nextPageUri);
-                }
-            }
-        }
-        return $totalTransactions;
+		// Parse page content
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors(true);
+		$dom->loadHTML($apiPageHTML[0]);
 
-    }
+		// Search for API keys
+		$xpath = new \DOMXPath($dom);
+		$contents = $xpath->query("//div[@class='uitkFields']/*");
+		if ($contents->length != 0) {
+			foreach ($contents as $i => $content) {
+				$value = $content->textContent;
+				if ($i == 0) {
+					$this->_accountSid = str_replace(array("\n", "\t", " "), "", $value);
+				} else if ($i == 1) {
+					$this->_authToken = str_replace(array("\n", "\t", " "), "", $value);
+				}
+			}
+		}
+	}
 
-    /**
-     * Get list of deals for all active campaings
-     * @return array
-     */
-    public function getDeals()
-    {
-        $a_deals = Array();
-        if (!$this->checkConnection()) {
-            return $a_deals;
-        }
-        $a_merchants = $this->getMerchantList();
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        foreach($a_merchants as $merchant) {
-            $merchant_id = $merchant['cid'];
-            $uri = "https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com/Mediapartners/" . $this->_accountSid . "/Campaigns/" . $merchant_id . "/Deals";
-            $res = \simplexml_load_file($uri);
-            $currentPage = (int)$res->Deals->attributes()->page;
-            $pageNumber = (int)$res->Deals->attributes()->numpages;
-            while ($currentPage <= $pageNumber) {
-                foreach ($res->Deals->Deal as $deal) {
-                    $obj = Array();
-                    $obj['id'] = (int)$deal->Id;
-                    $obj['name'] = (string)$deal->Name;
-                    $obj['description'] = (string)$deal->Description;
-                    $obj['campaign_id'] = (string)$deal->CampaignId;
-                    $obj['campaign_name'] = $merchant['name'];
-                    $obj['status'] = (string)$deal->State;
-                    $obj['type'] = (string)$deal->Type;
-                    $obj['discount_type'] = (string)$deal->DiscountType;
-                    $obj['discount_amount'] = (float)$deal->DiscountAmount;
-                    $obj['discount_currency'] = (string)$deal->DiscountCurrency;
-                    $obj['discount_percent'] = (float)$deal->DiscountPercent;
-                    $obj['discount_max_percent'] = (float)$deal->DiscountMaximumPercent;
-                    $obj['discount_percent_range_min'] = (float)$deal->DiscountPercentRangeStart;
-                    $obj['discount_percent_range_max'] = (float)$deal->DiscountPercentRangeEnd;
-                    $obj['promo_code'] = (string)$deal->DefaultPromoCode;
-                    $obj['minimum_purchase'] = (float)$deal->MinimumPurchaseAmount;
-                    $obj['minimum_purchase_currency'] = (string)$deal->MinimumPurchaseCurrency;
-                    $obj['url'] = ''; // (string)$deal->Uri;  // It' API url, not tracking url
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-                    if (!empty($deal->StartDate)) {
-                        $start_date = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$deal->StartDate, 0, 19));
-                        $obj['start_date'] = $start_date->format("Y-m-d H:i:s");
-                    }
-                    else {
-                        $obj['start_date'] = '';
-                    }
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials["password"] = $parameter;
 
-                    if (!empty($deal->EndDate)) {
-                        $end_date = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$deal->EndDate, 0, 19));
-                        $obj['end_date'] = $end_date->format("Y-m-d H:i:s");
-                    }
-                    else {
-                        $obj['end_date'] = '2099-12-31 00:00:00';
-                    }
+		return $credentials;
+	}
 
-                    $a_deals[] = $obj;
-                }
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		if (empty($this->_accountSid) || empty($this->_authToken)) {
+			return false;
+		}
+		return true;
+	}
 
-                $currentPage++;
-                $nextPageUri = (string)$res->Deals->attributes()->nextpageuri;
-                if ($nextPageUri != null) {
-                    $res = \simplexml_load_file("https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com" . $nextPageUri);
-                }
-            }
-        }
-        return $a_deals;
-    }
+	/**
+	 * It returns an array with the different merchants
+	 * @return array|null
+	 * @throws \Exception
+	 */
+	public function getMerchantList()
+	{
+		if (!is_null($this->_merchant_list) && is_array($this->_merchant_list)) {
+			return $this->_merchant_list;
+		}
+		$this->_merchant_list = Array();
+		if (!$this->checkConnection()) {
+			$this->_merchant_list;
+		}
+		$url_params = "/Mediapartners/" . $this->_accountSid . "/Campaigns";
+		$res = $this->makeCall($url_params);
+		$currentPage = (int)$res->Campaigns->attributes()->page;
+		$pageNumber = (int)$res->Campaigns->attributes()->numpages;
+		while ($currentPage <= $pageNumber) {
 
-    /**
-     * @return array
-     * @throws Exception
-     */
-    public function getPaymentHistory()
-    {
-        $paymentHistory = array();
+			foreach ($res->Campaigns->Campaign as $campaign) {
+				$obj = Array();
+				$obj['cid'] = (int)$campaign->CampaignId;
+				$obj['name'] = (string)$campaign->CampaignName;
+				$obj['url'] = (string)$campaign->CampaignUrl;
+				$obj['status'] = (string)$campaign->ContractStatus;
+				$this->_merchant_list[] = $obj;
+			}
 
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('https://app.impact.com/secure/nositemesh/accounting/getPayStubParamsCSV.csv', array());
-        $exportReport = $this->_client->get($urls);
-        $exportData = \str_getcsv($exportReport[0], "\n");
+			$currentPage++;
+			$nextPageUri = (string)$res->Campaigns->attributes()->nextpageuri;
+			if ($nextPageUri != null) {
+				$res = $this->makeCall($nextPageUri);
+			}
+		}
+		return $this->_merchant_list;
+	}
 
-        $num = \count($exportData);
-        for ($i = 1; $i < $num; $i++) {
-            $paymentExportArray = \str_getcsv($exportData[$i], ",");
-            $obj = array();
-            $date = \DateTime::createFromFormat("M d, Y", $paymentExportArray[1]);
-            $obj['date'] = $date->format("y-m-d H:i:s");
-            $obj['pid'] = $paymentExportArray[0];
-            $obj['method'] = 'BACS';
-            $obj['value'] = \Oara\Utilities::parseDouble($paymentExportArray[6]);
-            $paymentHistory[] = $obj;
-        }
-        return $paymentHistory;
-    }
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$totalTransactions = Array();
+
+		if (!$this->checkConnection()) {
+			return $totalTransactions;
+		}
+
+		//New Interface
+		$url_params = "/Mediapartners/" . $this->_accountSid . "/Actions?ActionDateStart=" . $dStartDate->format('Y-m-d\TH:i:s') . "-00:00&ActionDateEnd=" . $dEndDate->format('Y-m-d\TH:i:s') . "-00:00";
+		$res = $this->makeCall($url_params);
+
+		if ($res) {
+
+			$currentPage = (int)$res->Actions->attributes()->page;
+			$pageNumber = (int)$res->Actions->attributes()->numpages;
+			while ($currentPage <= $pageNumber) {
+
+				foreach ($res->Actions->Action as $action) {
+
+					/*
+					 * Example of transaction from API docs
+					  "Id": "3641.3299.182972",
+					  "CampaignId": 3641,
+					  "CampaignName": "Rocket-Powered Products",
+					  "ActionTrackerId": 9026,
+					  "ActionTrackerName": "irt-17721",
+					  "State": "PENDING",
+					  "AdId": 339815,
+					  "Payout": 32252.1922,
+					  "DeltaPayout": 32252.1922,
+					  "IntendedPayout": 32252.1922,
+					  "Amount": 32252.19,
+					  "DeltaAmount": 32252.19,
+					  "IntendedAmount": 32252.19,
+					  "Currency": "USD",
+					  "ReferringDate": "2017-01-11T22:18:42.000Z",
+					  "EventDate": "2017-01-12T19:52:07.000Z",
+					  "CreationDate": "2017-01-16T05:25:15.000Z",
+					  "LockingDate": "2017-02-16T08:00:00.000Z",
+					  "ClearedDate": "2017-02-31T08:00:00.000Z",
+					  "ReferringType": "CLICK_COOKIE",
+					  "ReferringDomain": "www.referring.com",
+					  "PromoCode": "SUMMER_PROMO",
+					  "Oid": "AZ3456-123V",
+					  "CustomerArea": "0",
+					  "CustomerCity": "New York",
+					  "CustomerRegion": "212",
+					  "CustomerCountry": "US",
+					  "SubId1": "custom1",
+					  "SubId2": "custom2",
+					  "SubId3": "custom3",
+					  "SharedId": "custom-shared",
+					  "Uri": "/Mediapartners/IRBcXt64v4pL159338fdubAiqsbdX65535/Actions/3641.3299.182972.json"
+					 */
+					$transaction = Array();
+					$transaction['unique_id'] = (string)$action->Id;
+					$transaction['merchant_id'] = (int)$action->CampaignId;
+					$transaction['merchant_name'] = (int)$action->CampaignName;
+
+					$transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->EventDate, 0, 19));
+					$transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
+
+					if ((string)$action->ReferringDate != '') {
+						// <slawn>
+						$transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->ReferringDate, 0, 19));
+						$transaction['date_click'] = $transactionDate->format("Y-m-d H:i:s");
+					} else {
+						$transaction['date_click'] = $transaction['date'];
+					}
+
+					if ((string)$action->SharedId != '') {
+						$transaction['custom_id'] = (string)$action->SharedId;
+					}
+					if ((string)$action->SubId1 != '') {
+						$transaction['custom_id'] = (string)$action->SubId1;
+					}
+
+					$status = (string)$action->State;
+					$statusArray[$status] = "";
+					if ($status == 'APPROVED' || $status == 'DEFAULT') {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} else {
+						if ($status == 'REVERSED' || $status == 'REJECTED') {
+							$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+						} else {
+							$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						}
+					}
+
+					$transaction['currency'] = (string)$action->Currency;
+					$transaction['amount'] = (double)$action->Amount;
+					$transaction['commission'] = (double)$action->Payout;
+					$transaction['commission_intended'] = (double)$action->IntendedPayout; // ??
+					$totalTransactions[] = $transaction;
+				}
+
+				$currentPage++;
+				$nextPageUri = (string)$res->Actions->attributes()->nextpageuri;
+				if ($nextPageUri != null) {
+					$res = $this->makeCall($nextPageUri);
+				}
+			}
+		}
+		return $totalTransactions;
+
+	}
+
+	/**
+	 * Get list of deals for all active campaigns
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getDeals()
+	{
+		$a_deals = Array();
+		if (!$this->checkConnection()) {
+			return $a_deals;
+		}
+		$a_merchants = $this->getMerchantList();
+
+		foreach ($a_merchants as $merchant) {
+			$merchant_id = $merchant['cid'];
+			$url_params = "/Mediapartners/" . $this->_accountSid . "/Campaigns/" . $merchant_id . "/Deals";
+			$res = $this->makeCall($url_params);
+			$currentPage = (int)$res->Deals->attributes()->page;
+			$pageNumber = (int)$res->Deals->attributes()->numpages;
+			while ($currentPage <= $pageNumber) {
+				foreach ($res->Deals->Deal as $deal) {
+					$obj = Array();
+					$obj['id'] = (int)$deal->Id;
+					$obj['name'] = (string)$deal->Name;
+					$obj['description'] = (string)$deal->Description;
+					$obj['campaign_id'] = (string)$deal->CampaignId;
+					$obj['campaign_name'] = $merchant['name'];
+					$obj['status'] = (string)$deal->State;
+					$obj['type'] = (string)$deal->Type;
+					$obj['discount_type'] = (string)$deal->DiscountType;
+					$obj['discount_amount'] = (float)$deal->DiscountAmount;
+					$obj['discount_currency'] = (string)$deal->DiscountCurrency;
+					$obj['discount_percent'] = (float)$deal->DiscountPercent;
+					$obj['discount_max_percent'] = (float)$deal->DiscountMaximumPercent;
+					$obj['discount_percent_range_min'] = (float)$deal->DiscountPercentRangeStart;
+					$obj['discount_percent_range_max'] = (float)$deal->DiscountPercentRangeEnd;
+					$obj['promo_code'] = (string)$deal->DefaultPromoCode;
+					$obj['minimum_purchase'] = (float)$deal->MinimumPurchaseAmount;
+					$obj['minimum_purchase_currency'] = (string)$deal->MinimumPurchaseCurrency;
+					$obj['url'] = ''; // (string)$deal->Uri;  // It' API url, not tracking url
+
+					if (!empty($deal->StartDate)) {
+						$start_date = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$deal->StartDate, 0, 19));
+						$obj['start_date'] = $start_date->format("Y-m-d H:i:s");
+					} else {
+						$obj['start_date'] = '';
+					}
+
+					if (!empty($deal->EndDate)) {
+						$end_date = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$deal->EndDate, 0, 19));
+						$obj['end_date'] = $end_date->format("Y-m-d H:i:s");
+					} else {
+						$obj['end_date'] = '2099-12-31 00:00:00';
+					}
+
+					$a_deals[] = $obj;
+				}
+
+				$currentPage++;
+				$nextPageUri = (string)$res->Deals->attributes()->nextpageuri;
+				if ($nextPageUri != null) {
+					$res = $this->makeCall($nextPageUri);
+				}
+			}
+		}
+		return $a_deals;
+	}
+
+	/**
+	 * @return array
+	 * @throws Exception
+	 */
+	public function getPaymentHistory()
+	{
+		$paymentHistory = array();
+
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('https://app.impact.com/secure/nositemesh/accounting/getPayStubParamsCSV.csv', array());
+		$exportReport = $this->_client->get($urls);
+		$exportData = \str_getcsv($exportReport[0], "\n");
+
+		$num = \count($exportData);
+		for ($i = 1; $i < $num; $i++) {
+			$paymentExportArray = \str_getcsv($exportData[$i], ",");
+			$obj = array();
+			$date = \DateTime::createFromFormat("M d, Y", $paymentExportArray[1]);
+			$obj['date'] = $date->format("y-m-d H:i:s");
+			$obj['pid'] = $paymentExportArray[0];
+			$obj['method'] = 'BACS';
+			$obj['value'] = \Oara\Utilities::parseDouble($paymentExportArray[6]);
+			$paymentHistory[] = $obj;
+		}
+		return $paymentHistory;
+	}
+
+	/**
+	 * @param string $params
+	 * @return \SimpleXMLElement
+	 * @throws \Exception
+	 */
+	private function makeCall($params = "")
+	{
+		$base_url = "https://" . $this->_accountSid . ":" . $this->_authToken . "@api.impactradius.com";
+
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $base_url . $params);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_POST, false);
+		$response = curl_exec($ch);
+		curl_close($ch);
+
+		if (strpos($response, '<Status>ERROR</Status>') !== false) {
+			throw new \Exception($response);
+		}
+
+		$xml_encode = utf8_encode($response);
+
+		//Convert the XML string into an SimpleXMLElement object.
+		$res = \simplexml_load_string($xml_encode, "SimpleXMLElement", \LIBXML_NOCDATA);
+
+		return $res;
+	}
 
 }

--- a/Oara/Network/Publisher/ImpactRadius.php
+++ b/Oara/Network/Publisher/ImpactRadius.php
@@ -44,16 +44,16 @@ class ImpactRadius extends \Oara\Network
      */
     public function login($credentials)
     {
-		
-		$this->_credentials = $credentials;
-		$this->_accountSid = $this->_credentials['api-sid'];
-        $this->_authToken = $this->_credentials['api-token'];
-		
-		return true;
-		
         $this->_credentials = $credentials;
-        $this->_client = new \Oara\Curl\Access($credentials);
 
+        if (isset($this->_credentials['api-sid']) && isset($this->_credentials['api-token'])) {
+            // <slawn> - Allow passing sid+token with credentials
+            $this->_accountSid = $this->_credentials['api-sid'];
+            $this->_authToken = $this->_credentials['api-token'];
+            return;
+        }
+        // Compatibility fallback - try to simulate login to access token
+        $this->_client = new \Oara\Curl\Access($credentials);
         $user = $this->_credentials['user'];
         $password = $this->_credentials['password'];
         $loginUrl = 'https://app.impact.com/secure/login.user';
@@ -227,16 +227,18 @@ class ImpactRadius extends \Oara\Network
                     $transaction['merchant_id'] = (int)$action->CampaignId;
                     $transaction['merchant_name'] = (int)$action->CampaignName;
 
+
                     $transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->EventDate,0,19));
                     $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
 
-					if((string)$action->ReferringDate != ''){
-						$transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->ReferringDate,0,19));
-						$transaction['date_click'] = $transactionDate->format("Y-m-d H:i:s");
-					}
-					else{
-						$transaction['date_click'] = $transaction['date'];
-					}
+                    if((string)$action->ReferringDate != ''){
+                        // <slawn>
+                        $transactionDate = \DateTime::createFromFormat("Y-m-d\TH:i:s", \substr((string)$action->ReferringDate,0,19));
+                        $transaction['date_click'] = $transactionDate->format("Y-m-d H:i:s");
+                    }
+                    else{
+                        $transaction['date_click'] = $transaction['date'];
+                    }
 
                     if ((string)$action->SharedId != '') {
                         $transaction['custom_id'] = (string)$action->SharedId;

--- a/Oara/Network/Publisher/ImpactRadius.php
+++ b/Oara/Network/Publisher/ImpactRadius.php
@@ -44,6 +44,13 @@ class ImpactRadius extends \Oara\Network
      */
     public function login($credentials)
     {
+		
+		$this->_credentials = $credentials;
+		$this->_accountSid = $this->_credentials['api-sid'];
+        $this->_authToken = $this->_credentials['api-token'];
+		
+		return true;
+		
         $this->_credentials = $credentials;
         $this->_client = new \Oara\Curl\Access($credentials);
 

--- a/Oara/Network/Publisher/LinkShare.php
+++ b/Oara/Network/Publisher/LinkShare.php
@@ -286,41 +286,15 @@ class LinkShare extends \Oara\Network
                 break;
             }
             if (empty($this->_sitesAllowed) || in_array($site->id, $this->_sitesAllowed)) {
-                echo "getting Transactions for site " . $site->id . "\n\n";
+                echo "LinkShare - Get Transactions for site " . $site->id . PHP_EOL;
 
                 // WARNING: You must create a custom report called exactly "Individual Item Report + Transaction ID + Currency"
                 // adding to the standard item report the columns "Transaction ID" and "Currency"
                 $url = "https://ran-reporting.rakutenmarketing.com/en/reports/Individual-Item-Report-%2B-Transaction-ID-%2B-Currency/filters?start_date=" . $dStartDate->format("Y-m-d") . "&end_date=" . $dEndDate->format("Y-m-d") . "&include_summary=N" . "&network=" . $this->_nid . "&tz=GMT&date_type=transaction&token=" . urlencode($site->token);
-                $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, $url);
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-                curl_setopt($ch, CURLOPT_TIMEOUT, 50);
-                curl_exec($ch);
-                $info = curl_getinfo($ch);
-                if ($info['http_code'] != 200) {
-                    return $totalTransactions;
-                } else {
-                    $result = file_get_contents($url);
-                }
-                curl_close($ch);
-                
+                $result = file_get_contents($url);
+
                 $url = "https://ran-reporting.rakutenmarketing.com/en/reports/signature-orders-report/filters?start_date=" . $dStartDate->format("Y-m-d") . "&end_date=" . $dEndDate->format("Y-m-d") . "&include_summary=N" . "&network=" . $this->_nid . "&tz=GMT&date_type=transaction&token=" . urlencode($site->token);
-                $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, $url);
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-                curl_setopt($ch, CURLOPT_TIMEOUT, 50);
-                curl_exec($ch);
-                $info = curl_getinfo($ch);
-                if ($info['http_code'] != 200) {
-                    return $totalTransactions;
-                } else {
-                    $resultSignature = file_get_contents($url);
-                }
-                curl_close($ch);
+                $resultSignature = file_get_contents($url);
 
                 $signatureMap = array();
                 $exportData = str_getcsv($resultSignature, "\n");

--- a/Oara/Network/Publisher/NetAffiliation.php
+++ b/Oara/Network/Publisher/NetAffiliation.php
@@ -1,24 +1,26 @@
 <?php
+
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+
 /**
  * API Class
  *
@@ -30,184 +32,183 @@ namespace Oara\Network\Publisher;
  */
 class NetAffiliation extends \Oara\Network
 {
-    protected $_sitesAllowed = array();
-    protected $_serverNumber = null;
-    protected $_credentials = null;
-    protected $_client = null;
+	protected $_sitesAllowed = array();
+	protected $_serverNumber = null;
+	protected $_credentials = null;
+	protected $_client = null;
 
-    /**
-     * @param $credentials
-     * @throws \Exception
-     * @throws \Oara\Curl\Exception
-     */
-    public function login($credentials)
-    {
+	/**
+	 * @param $credentials
+	 * @throws \Exception
+	 * @throws \Oara\Curl\Exception
+	 */
+	public function login($credentials)
+	{
 
-        $this->_credentials = $credentials;
-        $this->_client = new \Oara\Curl\Access($credentials);
-	    /**
-	     * 2019-06-10
-	     * Login page changed: Scraping is not possible anymore, API password must be passed from outside.
-	     */
-        $this->_credentials["apiPassword"] = $credentials['password'];
+		$this->_credentials = $credentials;
+		$this->_client = new \Oara\Curl\Access($credentials);
+		/**
+		 * 2019-06-10
+		 * Login page changed: Scraping is not possible anymore, API password must be passed from outside.
+		 */
+		$this->_credentials["apiPassword"] = $credentials['password'];
 
-    }
+	}
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials["password"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials["password"] = $parameter;
 
-        return $credentials;
-    }
+		return $credentials;
+	}
 
-    /**
-     * @return bool
-     */
-    public function checkConnection()
-    {
-	    /**
-	     * 2019-06-10
-	     * Check credentials by requiring an empty report
-	     * Successful query : « OK » string followed by a space and the number of lines recovered. A query can be successful and still not return any lines, just OK 0.
-	     * Failed query : « KO » string followed by a space and an error number, followed by a space and an explanation « humanly comprehensible ».
-	     *
-	     * ref. to http://wiki.netaffiliation.com/doku.php/en/diffuseurs/outils-techniques/webservices
-	     */
-	    $valuesFormExport = array();
-	    $valuesFormExport[] = new \Oara\Curl\Parameter('authl', $this->_credentials["user"]);
-	    $valuesFormExport[] = new \Oara\Curl\Parameter('authv', $this->_credentials["apiPassword"]);
-	    $urls = array();
-	    $urls[] = new \Oara\Curl\Request('https://stat.netaffiliation.com/requete.php?', $valuesFormExport);
-	    $exportReport = $this->_client->get($urls);
-		if (is_array($exportReport) && isset($exportReport[0])){
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		/**
+		 * 2019-06-10
+		 * Check credentials by requiring an empty report
+		 * Successful query : « OK » string followed by a space and the number of lines recovered. A query can be successful and still not return any lines, just OK 0.
+		 * Failed query : « KO » string followed by a space and an error number, followed by a space and an explanation « humanly comprehensible ».
+		 *
+		 * ref. to http://wiki.netaffiliation.com/doku.php/en/diffuseurs/outils-techniques/webservices
+		 */
+		$valuesFormExport = array();
+		$valuesFormExport[] = new \Oara\Curl\Parameter('authl', $this->_credentials["user"]);
+		$valuesFormExport[] = new \Oara\Curl\Parameter('authv', $this->_credentials["apiPassword"]);
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('https://stat.netaffiliation.com/requete.php?', $valuesFormExport);
+		$exportReport = $this->_client->get($urls);
+		if (is_array($exportReport) && isset($exportReport[0])) {
 
-			if (substr($exportReport[0], 0, 2) == 'OK'){
+			if (substr($exportReport[0], 0, 2) == 'OK') {
 				return true;
 			}
 		}
-	    return false;
+		return false;
 
-    }
+	}
 
-    /**
-     * @return array
-     */
-    public function getMerchantList()
-    {
-        $merchants = array();
+	/**
+	 * @return array
+	 */
+	public function getMerchantList()
+	{
+		$merchants = array();
+		try {
+			$url = 'http://flux.netaffiliation.com/xmltrack.php?sec=' . $_ENV['NETAFFILIATION_GET_MERCHANTS_KEY'];
 
-        try {
-            $valuesFormExport = array();
-            $urls = array();
-            $urls[] = new \Oara\Curl\Request('http://www' . $this->_serverNumber . '.netaffiliation.com/affiliate/webservice', $valuesFormExport);
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_POST, false);
+			$xml = curl_exec($ch);
+			curl_close($ch);
 
-            $exportReport = $this->_client->get($urls);
+			//Convert the XML string into an SimpleXMLElement object.
+			$xml = @\simplexml_load_string($xml, "SimpleXMLElement", \LIBXML_NOCDATA);
+			//Encode the SimpleXMLElement object into a JSON string.
+			$json = json_encode($xml);
+			$merchantArray = json_decode($json, TRUE);
+			foreach ($merchantArray["prog"] as $merchant) {
+				if (isset($merchant["@attributes"])) {
+					$obj = array();
+					$obj['cid'] = $merchant["@attributes"]["id"];
+					$obj['status'] = $merchant["@attributes"]["etat"];
+					if ($merchant["@attributes"]["etat"] == 'on') {
+						$obj['name'] = $merchant["title"];
+						$obj['url'] = $merchant["link"];
+						$obj['launch_date'] = $merchant['startdate']['@attributes']['date'];
+					} else {
+						$obj['name'] = null;
+						$obj['url'] = null;
+						$obj['launch_date'] = null;
+					}
+					$merchants[] = $obj;
+				}
+			}
+		} catch (\Exception $e) {
+			// Avoid lost of transactions if one date failed - <PN> - 2017-06-20
+			echo PHP_EOL . (New \DateTime())->format("d/m/Y H:i:s") . " - NetAffiliation - Error in getMerchantList: " . $e->getMessage() . PHP_EOL;
+			sleep(1);
+			return $merchants;
+		}
+		return $merchants;
+	}
 
-            if (\preg_match("/function genereCodeLogin\(\) { return '(.+)?'; }/", $exportReport[0], $match)) {
-                $content = \file_get_contents("http://flux.netaffiliation.com/flux_prog.php?taff=" . $match[1]);
-                $xml = @\simplexml_load_string($content, "SimpleXMLElement", \LIBXML_NOCDATA);
-                $json = \json_encode($xml);
-                $merchantArray = \json_decode($json, TRUE);
-                foreach ($merchantArray["prog"] as $merchant) {
-                    if (isset($merchant["@attributes"])) {
-                        $obj = array();
-                        $obj['cid'] = $merchant["@attributes"]["id"];
-                        $obj['status'] = $merchant["@attributes"]["etat"];
-                        if ($merchant["@attributes"]["etat"] == 'on') {
-                            $obj['name'] = $merchant["title"];
-                            $obj['url'] = $merchant["link"];
-                            $obj['launch_date'] = $merchant['startdate']['@attributes']['date'];
-                        }
-                        else {
-                            $obj['name'] = null;
-                            $obj['url'] = null;
-                            $obj['launch_date'] = null;
-                        }
-                        $merchants[] = $obj;
-                    }
-                }
-            }
-        }
-        catch(\Exception $e) {
-            // Avoid lost of transactions if one date failed - <PN> - 2017-06-20
-            echo PHP_EOL . (New \DateTime())->format("d/m/Y H:i:s") . " - NetAffiliation - Error in getMerchantList: " . $e->getMessage() . PHP_EOL;
-            sleep(1);
-            return $merchants;
-        }
-        return $merchants;
-    }
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$totalTransactions = array();
+		$merchantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
 
-    /**
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     * @throws Exception
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-        $totalTransactions = array();
-        $merchantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
-
-        $valuesFormExport = array();
-        $valuesFormExport[] = new \Oara\Curl\Parameter('authl', $this->_credentials["user"]);
-        $valuesFormExport[] = new \Oara\Curl\Parameter('authv', $this->_credentials["apiPassword"]);
-        $valuesFormExport[] = new \Oara\Curl\Parameter('champs', 'idprogramme,date,etat,argann,montant,gains,monnaie,idsite');
-        $valuesFormExport[] = new \Oara\Curl\Parameter('debut', $dStartDate->format("Y-m-d"));
-        $valuesFormExport[] = new \Oara\Curl\Parameter('fin', $dEndDate->format("Y-m-d"));
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('https://stat.netaffiliation.com/requete.php?', $valuesFormExport);
-        $exportReport = $this->_client->get($urls);
+		$valuesFormExport = array();
+		$valuesFormExport[] = new \Oara\Curl\Parameter('authl', $this->_credentials["user"]);
+		$valuesFormExport[] = new \Oara\Curl\Parameter('authv', $this->_credentials["apiPassword"]);
+		$valuesFormExport[] = new \Oara\Curl\Parameter('champs', 'idprogramme,date,etat,argann,montant,gains,monnaie,idsite');
+		$valuesFormExport[] = new \Oara\Curl\Parameter('debut', $dStartDate->format("Y-m-d"));
+		$valuesFormExport[] = new \Oara\Curl\Parameter('fin', $dEndDate->format("Y-m-d"));
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('https://stat.netaffiliation.com/requete.php?', $valuesFormExport);
+		$exportReport = $this->_client->get($urls);
 
 
-        //sales
-        $exportData = str_getcsv($exportReport[0], "\n");
-        $num = count($exportData);
-        for ($i = 1; $i < $num; $i++) {
-            $transactionExportArray = str_getcsv($exportData[$i], ";");
-            if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[7], $this->_sitesAllowed)) {
-                if (isset($merchantIdList[$transactionExportArray[0]])) {
-                    $transaction = Array();
-                    $transaction['merchantId'] = $transactionExportArray[0];
-                    $transactionDate = \DateTime::createFromFormat("d/m/Y H:i:s", $transactionExportArray[1]);
-                    $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
+		//sales
+		$exportData = str_getcsv($exportReport[0], "\n");
+		$num = count($exportData);
+		for ($i = 1; $i < $num; $i++) {
+			$transactionExportArray = str_getcsv($exportData[$i], ";");
+			if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[7], $this->_sitesAllowed)) {
+				if (isset($merchantIdList[$transactionExportArray[0]])) {
+					$transaction = Array();
+					$transaction['merchantId'] = $transactionExportArray[0];
+					$transactionDate = \DateTime::createFromFormat("d/m/Y H:i:s", $transactionExportArray[1]);
+					$transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
 
-                    if ($transactionExportArray[3] != null) {
-                        $transaction['custom_id'] = $transactionExportArray[3];
-                    }
+					if ($transactionExportArray[3] != null) {
+						$transaction['custom_id'] = $transactionExportArray[3];
+					}
 
-                    if (\strstr($transactionExportArray[2], 'v')) {
-                        $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-                    } else
-                        if (\strstr($transactionExportArray[2], 'r')) {
-                            $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-                        } else if (\strstr($transactionExportArray[2], 'a')) {
-                            $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-                        } else {
-                            throw new \Exception ("Status not found");
-                        }
-                    $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[5]);
-                    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[5]);
-                    $totalTransactions[] = $transaction;
-                }
-            }
-        }
-        return $totalTransactions;
-    }
+					if (\strstr($transactionExportArray[2], 'v')) {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} else
+						if (\strstr($transactionExportArray[2], 'r')) {
+							$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+						} else if (\strstr($transactionExportArray[2], 'a')) {
+							$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						} else {
+							throw new \Exception ("Status not found");
+						}
+					$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[5]);
+					$transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[5]);
+					$totalTransactions[] = $transaction;
+				}
+			}
+		}
+		return $totalTransactions;
+	}
 
 }

--- a/Oara/Network/Publisher/NetAffiliation.php
+++ b/Oara/Network/Publisher/NetAffiliation.php
@@ -113,7 +113,7 @@ class NetAffiliation extends \Oara\Network
 	{
 		$merchants = array();
 		try {
-			$url = 'http://flux.netaffiliation.com/xmltrack.php?sec=' . $_ENV['NETAFFILIATION_GET_MERCHANTS_KEY'];
+			$url = 'http://flux.netaffiliation.com/flux_prog.php?taff=' . $_ENV['NETAFFILIATION_GET_MERCHANTS_KEY'];
 
 			$ch = curl_init();
 			curl_setopt($ch, CURLOPT_URL, $url);

--- a/Oara/Network/Publisher/Publicidees.php
+++ b/Oara/Network/Publisher/Publicidees.php
@@ -94,16 +94,11 @@ class Publicidees extends \Oara\Network
      */
     public function checkConnection()
     {
-        $connection = true;
-/*
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('http://publisher.publicideas.com/', array());
-        $exportReport = $this->_client->get($urls);
-        if (\preg_match('/deconnexion\.php/', $exportReport[0], $matches)) {
-            $connection = true;
+        // Just check for valid credentiale
+        if (!empty($this->_user) && !empty($this->_password)) {
+            return true;
         }
-        */
-        return $connection;
+        return false;
     }
 
     /**

--- a/Oara/Network/Publisher/Publicidees.php
+++ b/Oara/Network/Publisher/Publicidees.php
@@ -249,7 +249,6 @@ class Publicidees extends \Oara\Network
                     $transaction['title'] = urldecode($action['Title']) ;
                     $transaction['currency'] = $action['ProgramCurrency'];
                     $transaction['custom_id'] = $action['SubID'];
-                    $transaction['status'] = null;
                     $transaction['approved'] = false;
                     $transaction['status'] = null;
                     if ($action['ActionStatus'] == 0) {

--- a/Oara/Network/Publisher/Publicidees.php
+++ b/Oara/Network/Publisher/Publicidees.php
@@ -146,7 +146,7 @@ class Publicidees extends \Oara\Network
             //$response = file_get_contents ('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd='.$dStartDate->format('Y-m-d').'&df='.$dEndDate->format('Y-m-d'));
             //$response = file_get_contents ('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd=2019-09-01&df='.$dEndDate->format('Y-m-d'));
 
-            $url = 'http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd=2019-09-01&df='.$dEndDate->format('Y-m-d');
+            $url = 'http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd='.$dStartDate->format('Y-m-d').'&df='.$dEndDate->format('Y-m-d');
 
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_URL, $url);

--- a/Oara/Network/Publisher/Publicidees.php
+++ b/Oara/Network/Publisher/Publicidees.php
@@ -116,20 +116,22 @@ class Publicidees extends \Oara\Network
     }
 
     /**
+	 *
+	 * ActionStatus = Status of Action
+	 * 0 = action refused
+	 * 1 = action pending
+	 * 2 = action approved
+	 * ActionType = Type of action
+	 * 3 = sales-based remuneration
+	 * 4 = form-based remuneration
+     * See: https://performance.timeonegroup.com/PDF/en_US/TimeOne_APISUBID_EN.pdf
      *
-     * ActionStatus = Status of Action
-     * 0 = action refused
-     * 1 = action pending
-     * 2 = action approved
-     * ActionType = Type of action
-     * 3 = sales-based remuneratio
-     * 4 = form-based remuneration
-     *
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     */
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
     public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
     {
         $totalTransactions = array();
@@ -220,7 +222,10 @@ class Publicidees extends \Oara\Network
                     */
                     $transaction = Array();
                     $transaction['merchantId'] = $program[0]['id'];
+                    //Order number
                     $transaction['unique_id'] = $action['id'];
+                    //commission ID
+                    $transaction['commission_id'] = $action['ProgramComID'];
                     $transaction['date'] = $action['ActionDate'];
                     $transaction["validation_date"] = $action['ValidationDate'];    // Future use - <PN>
                     $transaction['amount'] = $action['CartAmount'];

--- a/Oara/Network/Publisher/Publicidees.php
+++ b/Oara/Network/Publisher/Publicidees.php
@@ -1,24 +1,24 @@
 <?php
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
 
 /**
  * API Class
@@ -44,27 +44,27 @@ class Publicidees extends \Oara\Network
         $this->_user = $credentials['user'];
         $this->_password = $credentials['password'];
         $this->_client = new \Oara\Curl\Access($credentials);
-/*
-        $loginUrl = 'http://es.publicideas.com/logmein.php';
-        $valuesLogin = array(new \Oara\Curl\Parameter('loginAff', $user),
-            new \Oara\Curl\Parameter('passAff', $password),
-            new \Oara\Curl\Parameter('userType', 'aff')
-        );
+        /*
+                $loginUrl = 'http://es.publicideas.com/logmein.php';
+                $valuesLogin = array(new \Oara\Curl\Parameter('loginAff', $user),
+                    new \Oara\Curl\Parameter('passAff', $password),
+                    new \Oara\Curl\Parameter('userType', 'aff')
+                );
 
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
-        $exportReport = $this->_client->post($urls);
-        $result = \json_decode($exportReport[0]);
-        $loginUrl = 'http://publisher.publicideas.com/entree_affilies.php';
-        $valuesLogin = array(new \Oara\Curl\Parameter('login', $result->login),
-            new \Oara\Curl\Parameter('pass', $result->pass),
-            new \Oara\Curl\Parameter('submit', 'Ok'),
-            new \Oara\Curl\Parameter('h', $result->h)
-        );
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
-        $this->_client->post($urls);
-*/
+                $urls = array();
+                $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
+                $exportReport = $this->_client->post($urls);
+                $result = \json_decode($exportReport[0]);
+                $loginUrl = 'http://publisher.publicideas.com/entree_affilies.php';
+                $valuesLogin = array(new \Oara\Curl\Parameter('login', $result->login),
+                    new \Oara\Curl\Parameter('pass', $result->pass),
+                    new \Oara\Curl\Parameter('submit', 'Ok'),
+                    new \Oara\Curl\Parameter('h', $result->h)
+                );
+                $urls = array();
+                $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
+                $this->_client->post($urls);
+        */
     }
 
     /**
@@ -116,38 +116,44 @@ class Publicidees extends \Oara\Network
     }
 
     /**
-	 *
-	 * ActionStatus = Status of Action
-	 * 0 = action refused
-	 * 1 = action pending
-	 * 2 = action approved
-	 * ActionType = Type of action
-	 * 3 = sales-based remuneration
-	 * 4 = form-based remuneration
+     *
+     * ActionStatus = Status of Action
+     * 0 = action refused
+     * 1 = action pending
+     * 2 = action approved
+     * ActionType = Type of action
+     * 3 = sales-based remuneration
+     * 4 = form-based remuneration
      * See: https://performance.timeonegroup.com/PDF/en_US/TimeOne_APISUBID_EN.pdf
      *
-	 * @param null $merchantList
-	 * @param \DateTime|null $dStartDate
-	 * @param \DateTime|null $dEndDate
-	 * @return array
-	 * @throws \Exception
-	 */
+     * @param null $merchantList
+     * @param \DateTime|null $dStartDate
+     * @param \DateTime|null $dEndDate
+     * @return array
+     * @throws \Exception
+     */
     public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
     {
         $totalTransactions = array();
         try {
 
             //$response = file_get_contents ('http://api.publicidees.com/subid.php5?p=51238&k=c534b0f5dcdddb5f56caa70e4ff3ec3b');
-/*
-            echo "usr: ".$this->_user."<br>";
-            echo "pwd ".$this->_password."<br>";
-            echo "url: ".('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'')."<br>";
-*/
-            $response = file_get_contents ('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd='.$dStartDate->format('Y-m-d').'&df='.$dEndDate->format('Y-m-d'));
+            /*
+                        echo "usr: ".$this->_user."<br>";
+                        echo "pwd ".$this->_password."<br>";
+                        echo "url: ".('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'')."<br>";
+            */
+            //$response = file_get_contents ('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd='.$dStartDate->format('Y-m-d').'&df='.$dEndDate->format('Y-m-d'));
+            //$response = file_get_contents ('http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd=2019-09-01&df='.$dEndDate->format('Y-m-d'));
 
-            //echo "<br><br>RESPONSE<br><br>";
-            //var_dump($response);
+            $url = 'http://api.publicidees.com/subid.php5?p='.$this->_user.'&k='.$this->_password.'&dd=2019-09-01&df='.$dEndDate->format('Y-m-d');
 
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, false);
+            $response = curl_exec($ch);
+            curl_close($ch);
 
             //error messages returned by api call:
             //1) You reached the limit of 3 call(s) in the last 900 seconds (15 min). Try again later. Thank you
@@ -157,29 +163,38 @@ class Publicidees extends \Oara\Network
                 strpos($response, 'Wrong') !== false)
                 throw new \Exception($response);
 
+            $xml_encode = utf8_encode($response);
+
+            //Convert the XML string into an SimpleXMLElement object.
+            $ids = \simplexml_load_string($xml_encode, "SimpleXMLElement", \LIBXML_NOCDATA);
+
+            //echo "<br><br>RESPONSE<br><br>";
+            //var_dump($response);
+
+
             /*  XML PER TEST */
-/*
-            $response =
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-                <partner id='51238'>
-                    <program id='390'>
-                        <name>
-                            Wineandco
-                        </name>
-                        <action id=\"1826271-606458\" SubID=\"\" ActionDate=\"2017-04-12 14:32:54\" ValidationDate=\"\" ActionStatus=\"2\" ActionType=\"3\" ProgramCommission=\"10.000%\" ActionCommission=\"17.833\" CartAmount=\"178.33\" ProgramComID=\"835377\" PartnerComID=\"835018\" Title=\"Vente_NouveauClient\" ProgramCurrency=\"EUR\" Device=\"desktop\" />
-                    </program>
-                    <program id='546'>
-                        <name>
-                            <![CDATA[SexyAvenue FR]]>
-                        </name>
-                        <action id=\"24865487\" SubID=\"\" ActionDate=\"2017-04-12 16:44:10\" ValidationDate=\"\" ActionStatus=\"2\" ActionType=\"3\" ProgramCommission=\"20.000%\" ActionCommission=\"22.238\" CartAmount=\"111.19\" ProgramComID=\"73146\" PartnerComID=\"73146\" Title=\"Vente\" ProgramCurrency=\"EUR\" Device=\"desktop\" />
-                        <action id=\"24865308\" SubID=\"\" ActionDate=\"2017-04-12 13:27:26\" ValidationDate=\"\" ActionStatus=\"1\" ActionType=\"3\" ProgramCommission=\"20.000%\" ActionCommission=\"3.334\" CartAmount=\"16.67\" ProgramComID=\"73146\" PartnerComID=\"73146\" Title=\"Vente\" ProgramCurrency=\"EUR\" Device=\"mobile\" />
-                        <action id=\"24865456\" SubID=\"\" ActionDate=\"2017-04-12 15:28:46\" ValidationDate=\"\" ActionStatus=\"2\" ActionType=\"3\" ProgramCommission=\"20.000%\" ActionCommission=\"8.486\" CartAmount=\"42.43\" ProgramComID=\"73146\" PartnerComID=\"73146\" Title=\"Vente\" ProgramCurrency=\"EUR\" Device=\"desktop\" />
-                    </program>
-                </partner>
-            ";
-*/
-            $ids = new \SimpleXMLElement($response);
+            /*
+                        $response =
+                            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+                            <partner id='51238'>
+                                <program id='390'>
+                                    <name>
+                                        Wineandco
+                                    </name>
+                                    <action id=\"1826271-606458\" SubID=\"\" ActionDate=\"2017-04-12 14:32:54\" ValidationDate=\"\" ActionStatus=\"2\" ActionType=\"3\" ProgramCommission=\"10.000%\" ActionCommission=\"17.833\" CartAmount=\"178.33\" ProgramComID=\"835377\" PartnerComID=\"835018\" Title=\"Vente_NouveauClient\" ProgramCurrency=\"EUR\" Device=\"desktop\" />
+                                </program>
+                                <program id='546'>
+                                    <name>
+                                        <![CDATA[SexyAvenue FR]]>
+                                    </name>
+                                    <action id=\"24865487\" SubID=\"\" ActionDate=\"2017-04-12 16:44:10\" ValidationDate=\"\" ActionStatus=\"2\" ActionType=\"3\" ProgramCommission=\"20.000%\" ActionCommission=\"22.238\" CartAmount=\"111.19\" ProgramComID=\"73146\" PartnerComID=\"73146\" Title=\"Vente\" ProgramCurrency=\"EUR\" Device=\"desktop\" />
+                                    <action id=\"24865308\" SubID=\"\" ActionDate=\"2017-04-12 13:27:26\" ValidationDate=\"\" ActionStatus=\"1\" ActionType=\"3\" ProgramCommission=\"20.000%\" ActionCommission=\"3.334\" CartAmount=\"16.67\" ProgramComID=\"73146\" PartnerComID=\"73146\" Title=\"Vente\" ProgramCurrency=\"EUR\" Device=\"mobile\" />
+                                    <action id=\"24865456\" SubID=\"\" ActionDate=\"2017-04-12 15:28:46\" ValidationDate=\"\" ActionStatus=\"2\" ActionType=\"3\" ProgramCommission=\"20.000%\" ActionCommission=\"8.486\" CartAmount=\"42.43\" ProgramComID=\"73146\" PartnerComID=\"73146\" Title=\"Vente\" ProgramCurrency=\"EUR\" Device=\"desktop\" />
+                                </program>
+                            </partner>
+                        ";
+            */
+            //$ids = new \SimpleXMLElement($response);
 
             /*
                     foreach ($ids->program as $program) {

--- a/Oara/Network/Publisher/ShareASale.php
+++ b/Oara/Network/Publisher/ShareASale.php
@@ -314,6 +314,9 @@ class ShareASale extends \Oara\Network
 				$transaction['status'] = Utilities::STATUS_DECLINED;
 			} elseif (empty($locked) && !empty($lock_date)) {
 				$transaction['status'] = Utilities::STATUS_PENDING;
+			} elseif (!empty($locked) && 1 == $locked) {
+				//Locked transactions are transactions that are eligible for payment.
+				$transaction['status'] = Utilities::STATUS_CONFIRMED;
 			}
 
 			if (isset($transactionExportArray[22]) && $transactionExportArray[22] == 'Sale') {

--- a/Oara/Network/Publisher/ShareASale.php
+++ b/Oara/Network/Publisher/ShareASale.php
@@ -1,24 +1,29 @@
 <?php
+
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+
+use Oara\Utilities;
+
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+
 /**
  * Export Class
  *
@@ -30,184 +35,261 @@ namespace Oara\Network\Publisher;
  */
 class ShareASale extends \Oara\Network
 {
-    /**
-     * API Secret
-     * @var string
-     */
-    private $_apiSecret = null;
-    /**
-     * API Token
-     * @var string
-     */
-    private $_apiToken = null;
-    /**
-     * Merchant ID
-     * @var string
-     */
-    private $_affiliateId = null;
-    /**
-     * Api Version
-     * @var float
-     */
-    private $_apiVersion = null;
-    /**
-     * Api Server
-     * @var string
-     */
-    private $_apiServer = null;
+	/**
+	 * API Secret
+	 * @var string
+	 */
+	private $_apiSecret = null;
+	/**
+	 * API Token
+	 * @var string
+	 */
+	private $_apiToken = null;
+	/**
+	 * Merchant ID
+	 * @var string
+	 */
+	private $_affiliateId = null;
+	/**
+	 * Api Version
+	 * @var float
+	 */
+	private $_apiVersion = null;
+	/**
+	 * Api Server
+	 * @var string
+	 */
+	private $_apiServer = null;
 
-    /**
-     * Constructor and Login
-     * @param $credentials
-     * @return ShareASale
-     */
-    public function login($credentials)
-    {
-        $this->_affiliateId = \preg_replace("/[^0-9]/", "", $credentials['affiliateId']);
-        $this->_apiToken = $credentials['apiToken'];
-        $this->_apiSecret = $credentials['apiSecret'];
-        $this->_apiVersion = 1.8;
-        $this->_apiServer = "http://shareasale.com/x.cfm?";
-    }
+	/**
+	 * Constructor and Login
+	 * @param $credentials
+	 * @return ShareASale
+	 */
+	public function login($credentials)
+	{
+		$this->_affiliateId = preg_replace("/[^0-9]/", "", $credentials['affiliateId']);
+		$this->_apiToken = $credentials['apiToken'];
+		$this->_apiSecret = $credentials['apiSecret'];
+		$this->_apiVersion = 2.3;
+		$this->_apiServer = "http://shareasale.com/x.cfm?";
+	}
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-        $parameter = array();
-        $parameter["description"] = "Affiliate ID";
-        $parameter["required"] = true;
-        $parameter["name"] = "Affiliate ID";
-        $credentials["affiliateid"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "Affiliate ID";
+		$parameter["required"] = true;
+		$parameter["name"] = "Affiliate ID";
+		$credentials["affiliateid"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "API token";
-        $parameter["required"] = true;
-        $parameter["name"] = "API token";
-        $credentials["apitoken"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "API token";
+		$parameter["required"] = true;
+		$parameter["name"] = "API token";
+		$credentials["apitoken"] = $parameter;
 
-        $parameter = array();
-        $parameter["description"] = "API secret";
-        $parameter["required"] = true;
-        $parameter["name"] = "API secret";
-        $credentials["apisecret"] = $parameter;
+		$parameter = array();
+		$parameter["description"] = "API secret";
+		$parameter["required"] = true;
+		$parameter["name"] = "API secret";
+		$credentials["apisecret"] = $parameter;
 
-        return $credentials;
-    }
+		return $credentials;
+	}
 
-    /**
-     * @return bool
-     */
-    public function checkConnection()
-    {
-        $connection = true;
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = true;
 
-        $returnResult = self::makeCall("apitokencount");
-        if ($returnResult) {
-            //parse HTTP Body to determine result of request
-            if (\stripos($returnResult, "Error Code ")) { // error occurred
-                $connection = false;
-            }
-        } else { // connection error
-            $connection = false;
-        }
+		$returnResult = self::makeCall("apitokencount");
+		if ($returnResult) {
+			//parse HTTP Body to determine result of request
+			if (stripos($returnResult, "Error Code ")) { // error occurred
+				$connection = false;
+			}
+		} else { // connection error
+			$connection = false;
+		}
 
-        return $connection;
-    }
+		return $connection;
+	}
 
-    /**
-     * @return array
-     */
-    public function getMerchantList()
-    {
+	/**
+	 * @return array
+	 */
+	public function getMerchantList()
+	{
 
-        $merchants = array();
+		$merchants = array();
 
-        $returnResult = self::makeCall("merchantStatus");
-        $exportData = \str_getcsv($returnResult, "\r\n");
-        $num = \count($exportData);
-        for ($i = 1; $i < $num; $i++) {
-            $merchantArray = \str_getcsv($exportData[$i], "|");
-            if (\count($merchantArray) > 1) {
-                $obj = Array();
-                $obj['cid'] = (int)$merchantArray[0];
-                $obj['name'] = $merchantArray[1];
-                $merchants[] = $obj;
-            }
-        }
+		$returnResult = self::makeCall("merchantStatus");
+		$exportData = \str_getcsv($returnResult, "\r\n");
+		$num = \count($exportData);
+		for ($i = 1; $i < $num; $i++) {
+			$merchantArray = \str_getcsv($exportData[$i], "|");
+			if (\count($merchantArray) > 1) {
+				$obj = Array();
+				$obj['cid'] = (int)$merchantArray[0];
+				$obj['name'] = $merchantArray[1];
+				$merchants[] = $obj;
+			}
+		}
 
-        return $merchants;
-    }
+		return $merchants;
+	}
 
-    /**
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-        $totalTransactions = array();
-        $mechantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
-        $returnResult = self::makeCall("activity", "&dateStart=" . $dStartDate->format("m/d/Y") . "&dateEnd=" . $dEndDate->format("m/d/Y"));
-        $exportData = \str_getcsv($returnResult, "\r\n");
-        $num = \count($exportData);
-        for ($i = 1; $i < $num; $i++) {
-            $transactionExportArray = \str_getcsv($exportData[$i], "|");
-            if (\count($transactionExportArray) > 1 && isset($mechantIdList[(int)$transactionExportArray[2]])) {
-                $transaction = Array();
-                $merchantId = (int)$transactionExportArray[2];
-                $transaction['merchantId'] = $merchantId;
-                $transactionDate = \DateTime::createFromFormat("M-d-Y H:i:s", $transactionExportArray[3]);
-                $transaction['date'] = $transactionDate->format("yyyy-MM-dd HH:mm:ss");
-                $transaction['unique_id'] = (int)$transactionExportArray[0];
 
-                if ($transactionExportArray[1] != null) {
-                    $transaction['custom_id'] = $transactionExportArray[1];
-                }
+	/**
+	 * See: https://account.shareasale.com/a-apimanager.cfm?
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$totalTransactions = array();
 
-                if ($transactionExportArray[9] != null) {
-                    $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-                } else
-                    if ($transactionExportArray[8] != null) {
-                        $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-                    } else
-                        if ($transactionExportArray[7] != null) {
-                            $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-                        } else {
-                            $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-                        }
-                $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[4]);
-                $transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[5]);
-                $totalTransactions[] = $transaction;
-            }
-        }
-        return $totalTransactions;
-    }
+		$returnResult = self::makeCall("activity", "&dateStart=" . $dStartDate->format("m/d/Y") . "&dateEnd=" . $dEndDate->format("m/d/Y"));
+		if (stripos($returnResult, "Error Code ")) {
+			// error occurred
+			echo "[ShareASale][Error] " . $returnResult . PHP_EOL;
+			var_dump($returnResult);
+			throw new \Exception($returnResult);
+		}
+		$exportData = str_getcsv($returnResult, "\r\n");
+		$num = count($exportData);
+		for ($i = 1; $i < $num; $i++) {
+			$transactionExportArray = str_getcsv($exportData[$i], "|");
+			if (count($transactionExportArray) < 26) {
+				continue;
+			}
+			$transaction = Array();
+			$transaction['unique_id'] = (int)$transactionExportArray[0];
+			if (isset($transactionExportArray[1])) {
+				$transaction["affiliate_ID"] = (int)$transactionExportArray[1];
+			}
+			$transaction['merchantId'] = (int)$transactionExportArray[2];
+			if (isset($transactionExportArray[20])) {
+				$transaction['campaign_name'] = $transactionExportArray[20];
+			}
+			if (isset($transactionExportArray[3])) {
+				//ShareASale.com Inc. Chicago IL 60654
+				$transaction["date"] = new \DateTime($transactionExportArray[3], new \DateTimeZone('America/Chicago'));
+				$transaction["date"]->setTimezone(new \DateTimeZone('Europe/Rome'));
+			}
+			$transaction['amount'] = Utilities::parseDouble($transactionExportArray[4]);
+			$transaction['commission'] = Utilities::parseDouble($transactionExportArray[5]);
+			$transaction['currency'] = 'USD';
+			$comment = null;
+			if (isset($transactionExportArray[6])) {
+				$comment = $transactionExportArray[6];
+				$transaction['comment'] = $comment;
+			}
+			$voided = null;
+			if (isset($transactionExportArray[7])) {
+				$voided = $transactionExportArray[7];
+				$transaction["voided"] = $voided;
+			}
+			$pending_date = null;
+			if (isset($transactionExportArray[8])) {
+				$pending_date = $transactionExportArray[8];
+				$transaction["pending_date"] = $pending_date;
+			}
+			$locked = null;
+			if (isset($transactionExportArray[9])) {
+				$locked = $transactionExportArray[9];
+				$transaction["locked"] = $locked;
+			}
+			if (isset($transactionExportArray[10])) {
+				$transaction['custom_id'] = $transactionExportArray[10];
+			}
+			if (isset($transactionExportArray[11])) {
+				$transaction['referrer'] = $transactionExportArray[11];
+			}
+			$reversal_date = null;
+			if (isset($transactionExportArray[12])) {
+				$reversal_date = $transactionExportArray[12];
+				$transaction["reversal_date"] = $reversal_date;
+			}
+			if (isset($transactionExportArray[13]) && isset($transactionExportArray[14])) {
+				$str_to_time_date = strtotime($transactionExportArray[13]);
+				$date = date("Y-m-d", $str_to_time_date);
+				$str_to_time_time = strtotime($transactionExportArray[14]);
+				$time = date("H:i:s", $str_to_time_time);
+				$click_date = $date . " " . $time;
 
-    /**
-     * @param $actionVerb
-     * @param string $params
-     * @return mixed
-     */
-    private function makeCall($actionVerb, $params = "")
-    {
+				$transaction["click_date"] = new \DateTime($click_date, new \DateTimeZone('America/Chicago'));
+				$transaction["click_date"]->setTimezone(new \DateTimeZone('Europe/Rome'));
+			}
+			if (isset($transactionExportArray[15])) {
+				$banner_id = $transactionExportArray[15];
+				$transaction["banner_id"] = $banner_id;
+			}
+			if (isset($transactionExportArray[16])) {
+				$sku_list = $transactionExportArray[16];
+				$transaction["sku_list"] = $sku_list;
+			}
+			if (isset($transactionExportArray[17])) {
+				$quantity_list = $transactionExportArray[17];
+				$transaction["quantity_list"] = $quantity_list;
+			}
+			$lock_date = null;
+			if (isset($transactionExportArray[18])) {
+				$lock_date = $transactionExportArray[18];
+				$transaction["lock_date"] = $lock_date;
+			}
+			$paid_date = null;
+			if (isset($transactionExportArray[19])) {
+				$paid_date = $transactionExportArray[19];
+				$transaction["paid_date"] = $paid_date;
+			}
+			if (!empty($voided)) {
+				$transaction['status'] = Utilities::STATUS_DECLINED;
+			} elseif (empty($locked) && !empty($lock_date)) {
+				$transaction['status'] = Utilities::STATUS_PENDING;
+			}
 
-        $myTimeStamp = \gmdate(DATE_RFC1123);
-        $sig = $this->_apiToken . ':' . $myTimeStamp . ':' . $actionVerb . ':' . $this->_apiSecret;
+			if (isset($transactionExportArray[22]) && $transactionExportArray[22] == 'Sale') {
+				$transaction['trans_type'] = Utilities::TYPE_SALE;
+			} elseif (isset($transactionExportArray[22]) && $transactionExportArray[22] == 'Lead') {
+				$transaction['trans_type'] = Utilities::TYPE_LEAD;
+			}
+			$totalTransactions[] = $transaction;
+		}
+		return $totalTransactions;
+	}
 
-        $sigHash = \hash("sha256", $sig);
-        $myHeaders = array("x-ShareASale-Date: $myTimeStamp", "x-ShareASale-Authentication: $sigHash");
-        $ch = \curl_init();
-        \curl_setopt($ch, CURLOPT_URL, $this->_apiServer . "affiliateId=" . $this->_affiliateId . "&token=" . $this->_apiToken . "&version=" . $this->_apiVersion . "&action=" . $actionVerb . $params);
-        \curl_setopt($ch, CURLOPT_HTTPHEADER, $myHeaders);
-        \curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-        \curl_setopt($ch, CURLOPT_HEADER, 0);
-        $returnResult = \curl_exec($ch);
-        \curl_close($ch);
-        return $returnResult;
-    }
+	/**
+	 * @param $actionVerb
+	 * @param string $params
+	 * @return mixed
+	 */
+	private function makeCall($actionVerb, $params = "")
+	{
+
+		$myTimeStamp = gmdate(DATE_RFC1123);
+		$sig = $this->_apiToken . ':' . $myTimeStamp . ':' . $actionVerb . ':' . $this->_apiSecret;
+
+		$sigHash = hash("sha256", $sig);
+		$myHeaders = array("x-ShareASale-Date: $myTimeStamp", "x-ShareASale-Authentication: $sigHash");
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $this->_apiServer . "affiliateId=" . $this->_affiliateId . "&token=" . $this->_apiToken . "&version=" . $this->_apiVersion . "&action=" . $actionVerb . $params);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, $myHeaders);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+		curl_setopt($ch, CURLOPT_HEADER, 0);
+		$returnResult = curl_exec($ch);
+		curl_close($ch);
+		return $returnResult;
+	}
 }

--- a/Oara/Network/Publisher/TradeDoubler.php
+++ b/Oara/Network/Publisher/TradeDoubler.php
@@ -524,7 +524,7 @@ class TradeDoubler extends \Oara\Network
      */
     protected function toDate($dateString)
     {
-        $transactionDate = null;
+        $transactionDate = false;
         $hour_separator=':';
         if (strlen($dateString)>10){
             if (strpos(substr($dateString,10),'.')!==false){
@@ -535,7 +535,20 @@ class TradeDoubler extends \Oara\Network
             $transactionDate = \DateTime::createFromFormat("d/m/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
         } else
             if ($this->_dateFormat == 'M/d/yy') {
-                $transactionDate = \DateTime::createFromFormat("n/j/y H:i:s", \trim($dateString));
+                // Check for AM/PM time - 2019-04-15 <PN>
+                $transactionDate = \DateTime::createFromFormat("m/d/y h{$hour_separator}i{$hour_separator}s A", \trim($dateString));
+                if ($transactionDate === false) {
+                    // Check for H24 time
+                    $transactionDate = \DateTime::createFromFormat("m/d/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
+                }
+                if ($transactionDate === false) {
+                    // Try to get only the date
+                    $pos = strpos($dateString,' ');
+                    if ($pos !== false) {
+                        $dateString = substr($dateString, 0, $pos);
+                        $transactionDate = \DateTime::createFromFormat("m/d/y", trim($dateString));
+                    }
+                }
             } else
                 if ($this->_dateFormat == 'd/MM/yy') {
                     $transactionDate = \DateTime::createFromFormat("j/m/y H:i:s", \trim($dateString));
@@ -566,6 +579,9 @@ class TradeDoubler extends \Oara\Network
                                                 } else {
                                                     throw new \Exception("\n Date Format not supported " . $this->_dateFormat . "\n");
                                                 }
+        if ($transactionDate === false) {
+            throw new \Exception("TradeDoubler - Date Format not supported " . $this->_dateFormat . " for date: " . $dateString . "\n");
+        }
         return $transactionDate;
     }
 

--- a/Oara/Network/Publisher/TradeDoubler.php
+++ b/Oara/Network/Publisher/TradeDoubler.php
@@ -1,24 +1,26 @@
 <?php
+
 namespace Oara\Network\Publisher;
-    /**
-     * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
-     * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
-     *
-     * Copyright (C) 2016  Fubra Limited
-     * This program is free software: you can redistribute it and/or modify
-     * it under the terms of the GNU Affero General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or any later version.
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU Affero General Public License for more details.
-     * You should have received a copy of the GNU Affero General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     * Contact
-     * ------------
-     * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
-     **/
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+
 /**
  * Export Class
  *
@@ -31,687 +33,493 @@ namespace Oara\Network\Publisher;
 class TradeDoubler extends \Oara\Network
 {
 
-    protected $_sitesAllowed = array();
-    protected $_client = null;
-    protected $_dateFormat = null;
+	protected $_sitesAllowed = array();
+	protected $_client = null;
+	protected $_dateFormat = null;
+	protected $_apiUrl = 'https://connect.tradedoubler.com';
 
-    public function login($credentials)
-    {
+	public function login($credentials)
+	{
+		//https://tradedoubler.docs.apiary.io/#/reference/o-auth-2-0/bearer-and-refresh-token/bearer-token/200?mc=reference%2Fo-auth-2-0%2Fbearer-and-refresh-token%2Fbearer-token%2F200
+		$this->_credentials = $credentials;
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$this->_grant_type = 'password';
+		$this->getToken();
+	}
 
-        $this->_credentials = $credentials;
-        $this->_client = new \Oara\Curl\Access($credentials);
+	private function getToken()
+	{
+		try {
+			if (!empty($this->_token)) {
+				return $this->_token;
+			}
+			// Retrieve Bearer token
+			$loginUrl = $this->_apiUrl . '/uaa/oauth/token';
+			$client_id = (isset($_ENV['TRADEDOUBLER_CLIENT_ID'])) ? $_ENV['TRADEDOUBLER_CLIENT_ID'] : $this->_credentials['TRADEDOUBLER_CLIENT_ID'];
+			$client_secret = (isset($_ENV['TRADEDOUBLER_CLIENT_SECRET'])) ? $_ENV['TRADEDOUBLER_CLIENT_SECRET'] : $this->_credentials['TRADEDOUBLER_CLIENT_SECRET'];
+			$params = array(
+				new \Oara\Curl\Parameter('grant_type', $this->_grant_type),
+				new \Oara\Curl\Parameter('username', $this->_credentials['user']),
+				new \Oara\Curl\Parameter('password', $this->_credentials['password'])
+			);
 
-        $user = $this->_credentials['user'];
-        $password = $this->_credentials['password'];
-        $loginUrl = 'http://publisher.tradedoubler.com/pan/login';
+			$apiKey = base64_encode($client_id . ':' . $client_secret);
+			$p = array();
+			foreach ($params as $parameter) {
+				$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+			}
+			$post_params = implode('&', $p);
 
-        $valuesLogin = array(new \Oara\Curl\Parameter('j_username', $user),
-            new \Oara\Curl\Parameter('j_password', $password)
-        );
+			$ch = curl_init();
 
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
-        $this->_client->post($urls);
-    }
+			curl_setopt($ch, CURLOPT_URL, $loginUrl);
+			curl_setopt($ch, CURLOPT_POST, TRUE);
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $post_params);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Basic " . $apiKey, "Content-Type: application/x-www-form-urlencoded"));
 
-    /**
-     * @return array
-     */
-    public function getNeededCredentials()
-    {
-        $credentials = array();
+			$curl_results = curl_exec($ch);
+			curl_close($ch);
+			$response = json_decode($curl_results);
+			if ($response) {
+				if (isset($response->error)) {
+					if (isset($response->error_description)) {
+						throw new \Exception('[php-oara][Oara][Network][Publisher][TradeDoubler][getToken] ' . $response->error_description);
+					}
+				}
+				if (isset($response->access_token)) {
+					$this->_token = $response->access_token;
+				}
 
-        $parameter = array();
-        $parameter["description"] = "User Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "User";
-        $credentials["user"] = $parameter;
+			}
+			return $this->_token;
+		} catch (\Exception $e) {
+			throw new \Exception('[php-oara][Oara][Network][Publisher][TradeDoubler][getToken][Exception] ' . $e->getMessage());
+		}
 
-        $parameter = array();
-        $parameter["description"] = "Password to Log in";
-        $parameter["required"] = true;
-        $parameter["name"] = "Password";
-        $credentials["password"] = $parameter;
-
-        return $credentials;
-    }
-
-    /**
-     * @return bool
-     */
-    public function checkConnection()
-    {
-        $connection = false;
-
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
-        $exportReport = $this->_client->get($urls);
-
-        if (\preg_match('/\(([a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4})\)/', $exportReport[0], $match)) {
-            $this->_dateFormat = $match[1];
-        }
+	}
 
 
-        if ($this->_dateFormat != null) {
-            $connection = true;
-        }
-        return $connection;
-    }
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
 
-    /**
-     * @return array
-     */
-    public function getMerchantList()
-    {
-        $merchantReportList = self::getMerchantReportList();
-        $merchants = Array();
-        foreach ($merchantReportList as $key => $value) {
-            $obj = Array();
-            $obj['cid'] = $key;
-            $obj['name'] = $value;
-            $merchants[] = $obj;
-        }
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
 
-        return $merchants;
-    }
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials["password"] = $parameter;
 
-    /**
-     * It returns an array with the different merchants
-     * @return array
-     */
-    private function getMerchantReportList()
-    {
+		return $credentials;
+	}
 
-        $valuesFormExport = array(new \Oara\Curl\Parameter('reportName', 'aAffiliateMyProgramsReport'),
-            new \Oara\Curl\Parameter('tabMenuName', ''),
-            new \Oara\Curl\Parameter('isPostBack', ''),
-            new \Oara\Curl\Parameter('showAdvanced', 'true'),
-            new \Oara\Curl\Parameter('showFavorite', 'false'),
-            new \Oara\Curl\Parameter('run_as_organization_id', ''),
-            new \Oara\Curl\Parameter('minRelativeIntervalStartTime', '0'),
-            new \Oara\Curl\Parameter('maxIntervalSize', '0'),
-            new \Oara\Curl\Parameter('interval', 'MONTHS'),
-            new \Oara\Curl\Parameter('reportPrograms', ''),
-            new \Oara\Curl\Parameter('reportTitleTextKey', 'REPORT3_SERVICE_REPORTS_AAFFILIATEMYPROGRAMSREPORT_TITLE'),
-            new \Oara\Curl\Parameter('setColumns', 'true'),
-            new \Oara\Curl\Parameter('latestDayToExecute', '0'),
-            new \Oara\Curl\Parameter('affiliateId', ''),
-            new \Oara\Curl\Parameter('includeWarningColumn', 'true'),
-            new \Oara\Curl\Parameter('sortBy', 'orderDefault'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'programId'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'affiliateId'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'applicationDate'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'status'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'useMetricColumn'),
-            new \Oara\Curl\Parameter('customKeyMetricCount', '0'),
-            new \Oara\Curl\Parameter('metric1.name', ''),
-            new \Oara\Curl\Parameter('metric1.midFactor', ''),
-            new \Oara\Curl\Parameter('metric1.midOperator', '/'),
-            new \Oara\Curl\Parameter('metric1.columnName1', 'programId'),
-            new \Oara\Curl\Parameter('metric1.operator1', '/'),
-            new \Oara\Curl\Parameter('metric1.columnName2', 'programId'),
-            new \Oara\Curl\Parameter('metric1.lastOperator', '/'),
-            new \Oara\Curl\Parameter('metric1.factor', ''),
-            new \Oara\Curl\Parameter('metric1.summaryType', 'NONE'),
-            new \Oara\Curl\Parameter('format', 'CSV'),
-            new \Oara\Curl\Parameter('separator', ','),
-            new \Oara\Curl\Parameter('dateType', '0'),
-            new \Oara\Curl\Parameter('favoriteId', ''),
-            new \Oara\Curl\Parameter('favoriteName', ''),
-            new \Oara\Curl\Parameter('favoriteDescription', ''),
-            new \Oara\Curl\Parameter('programAffiliateStatusId', '3')
-        );
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Internal.action?', $valuesFormExport);
-        $exportReport = $this->_client->post($urls);
-        $exportReport[0] = self::checkReportError($exportReport[0], $urls[0]);
-        $merchantReportList = self::getExportMerchantReport($exportReport[0]);
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = true;
+		return $connection;
+	}
 
-        $valuesFormExport = array(new \Oara\Curl\Parameter('reportName', 'aAffiliateMyProgramsReport'),
-            new \Oara\Curl\Parameter('tabMenuName', ''),
-            new \Oara\Curl\Parameter('isPostBack', ''),
-            new \Oara\Curl\Parameter('showAdvanced', 'true'),
-            new \Oara\Curl\Parameter('showFavorite', 'false'),
-            new \Oara\Curl\Parameter('run_as_organization_id', ''),
-            new \Oara\Curl\Parameter('minRelativeIntervalStartTime', '0'),
-            new \Oara\Curl\Parameter('maxIntervalSize', '0'),
-            new \Oara\Curl\Parameter('interval', 'MONTHS'),
-            new \Oara\Curl\Parameter('reportPrograms', ''),
-            new \Oara\Curl\Parameter('reportTitleTextKey', 'REPORT3_SERVICE_REPORTS_AAFFILIATEMYPROGRAMSREPORT_TITLE'),
-            new \Oara\Curl\Parameter('setColumns', 'true'),
-            new \Oara\Curl\Parameter('latestDayToExecute', '0'),
-            new \Oara\Curl\Parameter('affiliateId', ''),
-            new \Oara\Curl\Parameter('includeWarningColumn', 'true'),
-            new \Oara\Curl\Parameter('sortBy', 'orderDefault'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'programId'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'affiliateId'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'applicationDate'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
-            new \Oara\Curl\Parameter('columns', 'status'),
-            new \Oara\Curl\Parameter('autoCheckbox', 'useMetricColumn'),
-            new \Oara\Curl\Parameter('customKeyMetricCount', '0'),
-            new \Oara\Curl\Parameter('metric1.name', ''),
-            new \Oara\Curl\Parameter('metric1.midFactor', ''),
-            new \Oara\Curl\Parameter('metric1.midOperator', '/'),
-            new \Oara\Curl\Parameter('metric1.columnName1', 'programId'),
-            new \Oara\Curl\Parameter('metric1.operator1', '/'),
-            new \Oara\Curl\Parameter('metric1.columnName2', 'programId'),
-            new \Oara\Curl\Parameter('metric1.lastOperator', '/'),
-            new \Oara\Curl\Parameter('metric1.factor', ''),
-            new \Oara\Curl\Parameter('metric1.summaryType', 'NONE'),
-            new \Oara\Curl\Parameter('format', 'CSV'),
-            new \Oara\Curl\Parameter('separator', ','),
-            new \Oara\Curl\Parameter('dateType', '0'),
-            new \Oara\Curl\Parameter('favoriteId', ''),
-            new \Oara\Curl\Parameter('favoriteName', ''),
-            new \Oara\Curl\Parameter('favoriteDescription', ''),
-            new \Oara\Curl\Parameter('programAffiliateStatusId', '4')
-        );
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Internal.action?', $valuesFormExport);
-        $exportReport = $this->_client->post($urls);
-        $exportReport[0] = self::checkReportError($exportReport[0], $urls[0]);
-        $merchantReportListAux = self::getExportMerchantReport($exportReport[0]);
-        foreach ($merchantReportListAux as $key => $value) {
-            $merchantReportList[$key] = $value;
-        }
-        return $merchantReportList;
-    }
+	/**
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getMerchantList()
+	{
+		$merchants = Array();
+		try {
+			//https://tradedoubler.docs.apiary.io/#/reference/programs/program/list-programs/200?mc=reference%2Fprograms%2Fprogram%2Flist-programs%2F200
+			$url_programs = $this->_apiUrl . '/publisher/programs';
+			$limit = 100;
+			$offset = 0;
+			$loop = true;
 
-    public function checkReportError($content, $request, $try = 0)
-    {
+			while ($loop) {
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_URL, $url_programs . '?sourceId=' . $this->_credentials['idSite'] . '&limit=' . $limit . '&offset=' . $offset);
+				curl_setopt($ch, CURLOPT_POST, false);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
 
-        if (\preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
-            //report too big, we have to download it and read it
-            if (\preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
+				$curl_results = curl_exec($ch);
+				curl_close($ch);
+				$a_merchants = json_decode($curl_results, true);
+				if (isset($a_merchants[0]['code']) && isset($a_merchants[0]['message'])) {
+					$loop = false;
+					throw new \Exception('[php-oara][Oara][Network][Publisher][TradeDoubler][getMerchantList] ' . $a_merchants[0]['message']);
+				} elseif (isset($a_merchants['items']) && isset($a_merchants['total'])) {
+					foreach ($a_merchants['items'] as $merchantJson) {
+						$obj = Array();
+						$obj['cid'] = $merchantJson['id'];
+						$obj['name'] = $merchantJson['name'];
+						//Possible values: 0: Not Applied, 1: Under Consideration, 2: On-hold while under consideration, 3: Accepted, 4: Ended, 5: Denied, 6: On Hold while Accepted, 7: Final Denied, 8: Written Off
+						switch ($merchantJson['statusId']) {
+							case 0:
+								$obj['status'] = 'Not Applied';
+								break;
+							case 1:
+								$obj['status'] = ' Under Consideration';
+								break;
+							case 2:
+								$obj['status'] = 'On-hold while under consideration';
+								break;
+							case 3:
+								$obj['status'] = 'Accepted';
+								break;
+							case 4:
+								$obj['status'] = 'Ended';
+								break;
+							case 5:
+								$obj['status'] = 'Denied';
+								break;
+							case 6:
+								$obj['status'] = 'On Hold while Accepted';
+								break;
+							case 7:
+								$obj['status'] = 'Final Denied';
+								break;
+							case 8:
+								$obj['status'] = 'Written Off';
+								break;
+							default:
+								$obj['status'] = 'Unknown';
+								echo '[php-oara][Oara][Network][Publisher][TradeDoubler][getMerchantList] Merchant status unexpected ' . $merchantJson['statusId'];
+								break;
+						}
+						$obj['launch_date'] = $merchantJson['startDate'];
+						$obj['application_date'] = $merchantJson['applicationDate'];
+						$merchants[] = $obj;
+					}
+					if ((int)$a_merchants['total'] <= $offset) {
+						$loop = false;
+					}
+					$offset = (int)($limit + $offset);
+				} else {
+					echo '[php-oara][Oara][Network][Publisher][TradeDoubler][getMerchantList] invalid response';
+					$loop = false;
+				}
+			}
+		} catch (\Exception $e) {
+			throw new \Exception('[php-oara][Oara][Network][Publisher][TradeDoubler][getMerchantList][Exception] ' . $e->getMessage());
+		}
+		return $merchants;
+	}
 
-                $file = "http://publisher.tradedoubler.com" . $matches[0];
-                $newfile = \realpath(\dirname(COOKIES_BASE_DIR)) . '/pdf/' . $matches[2] . '.zip';
 
-                if (!\copy($file, $newfile)) {
-                    throw new \Exception('Failing copying the zip file \n\n');
-                }
-                $zip = new \ZipArchive();
-                if ($zip->open($newfile, \ZIPARCHIVE::CREATE) !== TRUE) {
-                    throw new \Exception('Cannot open zip file \n\n');
-                }
-                $zip->extractTo(\realpath(\dirname(COOKIES_BASE_DIR)) . '/pdf/');
-                $zip->close();
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$totalTransactions = array();
 
-                $unzipFilePath = \realpath(\dirname(COOKIES_BASE_DIR)) . '/pdf/' . $matches[2];
-                $fileContent = \file_get_contents($unzipFilePath);
-                \unlink($newfile);
-                \unlink($unzipFilePath);
-                return $fileContent;
-            }
+		try {
+			$limit = 100;
+			$offset = 0;
+			$loop = true;
 
-            throw new \Exception('Report too big \n\n');
-
-        } else
-            if (\preg_match("/ error/", $content, $matches)) {
-                $urls = array();
-                $urls[] = $request;
-                $exportReport = $this->_client->get($urls);
-                $try++;
-                if ($try < 5) {
-                    return self::checkReportError($exportReport[0], $request, $try);
-                } else {
-                    throw new \Exception('Problem checking report\n\n');
-                }
-
+			if (isset($_ENV['TRADEDOUBLER_CURRENCY'])) {
+				$currency = $_ENV['TRADEDOUBLER_CURRENCY'];
+            } elseif (isset($this->_credentials['TRADEDOUBLER_CURRENCY'])){
+                $currency = $this->_credentials['TRADEDOUBLER_CURRENCY'];
             } else {
-                return $content;
-            }
+				$currency = 'EUR';
+			}
+			while ($loop) {
+				/**
+				 * https://tradedoubler.docs.apiary.io/#/reference/reporting/transaction/list-transaction/200?mc=reference%2Freporting%2Ftransaction%2Flist-transaction%2F200
+				 * The values for dates should be in format Ymd
+				 * Returns the result in the JSON format
+				 */
+				$url_transactions = $this->_apiUrl . '/publisher/report/transactions';
+				$params = array(
+					new \Oara\Curl\Parameter('reportCurrencyCode', $currency),
+					new \Oara\Curl\Parameter('fromDate', $dStartDate->format("Ymd")),
+					new \Oara\Curl\Parameter('toDate', $dEndDate->format("Ymd")),
+					new \Oara\Curl\Parameter('limit', $limit),
+					new \Oara\Curl\Parameter('offset', $offset)
+				);
 
-    }
+				$p = array();
+				foreach ($params as $parameter) {
+					$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+				}
+				$get_params = implode('&', $p);
 
-    /**
-     * @param $content
-     * @return array
-     */
-    private function getExportMerchantReport($content)
-    {
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_URL, $url_transactions . '?' . $get_params);
+				curl_setopt($ch, CURLOPT_POST, false);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $this->getToken(), "Content-Type: application/x-www-form-urlencoded"));
 
-        $merchantReport = self::formatCsv($content);
+				$curl_results = curl_exec($ch);
+				curl_close($ch);
+				$transactionsList = json_decode($curl_results, true);
+				foreach ($transactionsList['items'] as $transactionJson) {
 
-        $exportData = \str_getcsv($merchantReport, "\r\n");
-        $merchantReportList = Array();
-        $num = \count($exportData);
-        $websiteMap = array();
-        for ($i = 3; $i < $num; $i++) {
-            $merchantExportArray = \str_getcsv($exportData[$i], ",");
-
-            if ($merchantExportArray[2] != '' && $merchantExportArray[4] != '') {
-                $merchantReportList[$merchantExportArray[4]] = $merchantExportArray[2];
-                $websiteMap[$merchantExportArray[0]] = "";
-            }
-
-        }
-        return $merchantReportList;
-    }
-
-    /**
-     * @param $csv
-     * @return mixed
-     */
-    private function formatCsv($csv)
-    {
-        \preg_match_all("/\"([^\"]+?)\",/", $csv, $matches);
-        foreach ($matches[1] as $match) {
-            if (\preg_match("/,/", $match)) {
-                $rep = \preg_replace("/,/", "", $match);
-                $csv = \str_replace($match, $rep, $csv);
-                $match = $rep;
-            }
-            if (\preg_match("/\n/", $match)) {
-                $rep = \preg_replace("/\n/", "", $match);
-                $csv = \str_replace($match, $rep, $csv);
-            }
-        }
-        return $csv;
-    }
-
-    /**
-     * @param null $merchantList
-     * @param \DateTime|null $dStartDate
-     * @param \DateTime|null $dEndDate
-     * @return array
-     * @throws Exception
-     */
-    public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
-    {
-        $merchantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
-
-        $totalTransactions = Array();
-        $valuesFormExport = array(new \Oara\Curl\Parameter('reportName', 'aAffiliateEventBreakdownReport'),
-            new \Oara\Curl\Parameter('columns', 'programId'),
-            new \Oara\Curl\Parameter('columns', 'timeOfVisit'),
-            new \Oara\Curl\Parameter('columns', 'timeOfEvent'),
-            new \Oara\Curl\Parameter('columns', 'timeInSession'),
-            new \Oara\Curl\Parameter('columns', 'lastModified'),
-            new \Oara\Curl\Parameter('columns', 'epi1'),
-            new \Oara\Curl\Parameter('columns', 'eventName'),
-            new \Oara\Curl\Parameter('columns', 'pendingStatus'),
-            new \Oara\Curl\Parameter('columns', 'siteName'),
-            new \Oara\Curl\Parameter('columns', 'graphicalElementName'),
-            new \Oara\Curl\Parameter('columns', 'graphicalElementId'),
-            new \Oara\Curl\Parameter('columns', 'productName'),
-            new \Oara\Curl\Parameter('columns', 'productNrOf'),
-            new \Oara\Curl\Parameter('columns', 'productValue'),
-            new \Oara\Curl\Parameter('columns', 'affiliateCommission'),
-            new \Oara\Curl\Parameter('columns', 'link'),
-            new \Oara\Curl\Parameter('columns', 'leadNR'),
-            new \Oara\Curl\Parameter('columns', 'orderNR'),
-            new \Oara\Curl\Parameter('columns', 'pendingReason'),
-            new \Oara\Curl\Parameter('columns', 'orderValue'),
-            new \Oara\Curl\Parameter('isPostBack', ''),
-            new \Oara\Curl\Parameter('metric1.lastOperator', '/'),
-            new \Oara\Curl\Parameter('interval', ''),
-            new \Oara\Curl\Parameter('favoriteDescription', ''),
-            new \Oara\Curl\Parameter('event_id', '0'),
-            new \Oara\Curl\Parameter('pending_status', '1'),
-            new \Oara\Curl\Parameter('run_as_organization_id', ''),
-            new \Oara\Curl\Parameter('minRelativeIntervalStartTime', '0'),
-            new \Oara\Curl\Parameter('includeWarningColumn', 'true'),
-            new \Oara\Curl\Parameter('metric1.summaryType', 'NONE'),
-            new \Oara\Curl\Parameter('metric1.operator1', '/'),
-            new \Oara\Curl\Parameter('latestDayToExecute', '0'),
-            new \Oara\Curl\Parameter('showAdvanced', 'true'),
-            new \Oara\Curl\Parameter('breakdownOption', '1'),
-            new \Oara\Curl\Parameter('metric1.midFactor', ''),
-            new \Oara\Curl\Parameter('reportTitleTextKey', 'REPORT3_SERVICE_REPORTS_AAFFILIATEEVENTBREAKDOWNREPORT_TITLE'),
-            new \Oara\Curl\Parameter('setColumns', 'true'),
-            new \Oara\Curl\Parameter('metric1.columnName1', 'orderValue'),
-            new \Oara\Curl\Parameter('metric1.columnName2', 'orderValue'),
-            new \Oara\Curl\Parameter('reportPrograms', ''),
-            new \Oara\Curl\Parameter('metric1.midOperator', '/'),
-            new \Oara\Curl\Parameter('dateSelectionType', '1'),
-            new \Oara\Curl\Parameter('favoriteName', ''),
-            new \Oara\Curl\Parameter('affiliateId', ''),
-            new \Oara\Curl\Parameter('dateType', '1'),
-            new \Oara\Curl\Parameter('period', 'custom_period'),
-            new \Oara\Curl\Parameter('tabMenuName', ''),
-            new \Oara\Curl\Parameter('maxIntervalSize', '0'),
-            new \Oara\Curl\Parameter('favoriteId', ''),
-            new \Oara\Curl\Parameter('sortBy', 'timeOfEvent'),
-            new \Oara\Curl\Parameter('metric1.name', ''),
-            new \Oara\Curl\Parameter('customKeyMetricCount', '0'),
-            new \Oara\Curl\Parameter('metric1.factor', ''),
-            new \Oara\Curl\Parameter('showFavorite', 'false'),
-            new \Oara\Curl\Parameter('separator', ','),
-            new \Oara\Curl\Parameter('format', 'CSV')
-        );
-        $valuesFormExport[] = new \Oara\Curl\Parameter('startDate', self::formatDate($dStartDate));
-        $valuesFormExport[] = new \Oara\Curl\Parameter('endDate', self::formatDate($dEndDate));
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Internal.action?', $valuesFormExport);
-        $exportReport = $this->_client->get($urls);
-
-        $exportReport[0] = self::checkReportError($exportReport[0], $urls[0]);
-        $exportData = \str_getcsv($exportReport[0], "\r\n");
-        $num = \count($exportData);
-        for ($i = 2; $i < $num - 1; $i++) {
-
-            $transactionExportArray = \str_getcsv($exportData[$i], ",");
-
-            if (!isset($transactionExportArray[2])) {
-                throw new \Exception('Problem getting transaction\n\n');
-            }
-            if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[13], $this->_sitesAllowed)) {
+					$transaction = Array();
+					if (isset($transactionJson['orderNumber']) && !empty($transactionJson['orderNumber'])) {
+						$transaction['unique_id'] = $transactionJson['orderNumber'];
+						$eventTypeId = $transactionJson['eventTypeId'];
+						$transaction['action'] = \Oara\Utilities::TYPE_SALE;
+					} elseif (isset($transactionJson['leadNumber']) && !empty($transactionJson['leadNumber'])) {
+						$transaction['unique_id'] = $transactionJson['leadNumber'];
+						$eventTypeId = $transactionJson['eventTypeId'];
+						$transaction['action'] = \Oara\Utilities::TYPE_LEAD;
+					} else {
+						//Cannot identified an unique attribute for the transaction
+						echo '[php-oara][Oara][Network][Publisher][TradeDoubler][getTransactionList] Cannot identified an unique attribute for the transaction ' . $transactionJson;
+						continue;
+					}
+					$transaction['event_id'] = $transactionJson['eventId'];
+					$transaction['merchantId'] = $transactionJson['programId'];
+					$transaction['merchantName'] = $transactionJson['programName'];
+					$transaction['date'] = $transactionJson['timeOfTransaction'];
+					$transaction['click_date'] = $transactionJson['timeOfLastClick'];
+					$transaction['update_date'] = $transactionJson['timeOfLastModified'];
+					$transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson['orderValue']);
+					$transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson['commission']);
+					$transaction['currency'] = $transactionsList['reportCurrencyCode'];
+					$transaction['custom_id'] = $transactionJson['epi'];
+					if ($transactionJson['status'] == 'A') {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} elseif ($transactionJson['status'] == 'P') {
+						$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+					} elseif ($transactionJson['status'] == 'D') {
+						$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+					} else {
+						$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						echo '[php-oara][Oara][Network][Publisher][TradeDoubler][getTransactionList] Transaction status unexpected ' . $transactionJson['status'];
+					}
+					$totalTransactions[] = $transaction;
+				}
+				if ((int)count($transactionsList['items']) < $limit) {
+					$loop = false;
+				}
+				$offset = (int)($limit + $offset);
+			}
+		} catch (\Exception $e) {
+			throw new \Exception('[php-oara][Oara][Network][Publisher][TradeDoubler][getTransactionList][Exception] ' . $e->getMessage());
+		}
+		return $totalTransactions;
+	}
 
 
-                if ($transactionExportArray[0] !== '' && isset($merchantIdList[(int)$transactionExportArray[2]])) {
+	/**
+	 * @param $dateString
+	 * @return bool|\DateTime
+	 * @throws \Exception
+	 */
+	protected function toDate($dateString)
+	{
+		$transactionDate = false;
+		$hour_separator = ':';
+		if (strlen($dateString) > 10) {
+			if (strpos(substr($dateString, 10), '.') !== false) {
+				$hour_separator = '.';
+			}
+		}
+		if ($this->_dateFormat == 'dd/MM/yy') {
+			$transactionDate = \DateTime::createFromFormat("d/m/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
+		} else
+			if ($this->_dateFormat == 'M/d/yy') {
+				// Check for AM/PM time - 2019-04-15 <PN>
+				$transactionDate = \DateTime::createFromFormat("m/d/y h{$hour_separator}i{$hour_separator}s A", \trim($dateString));
+				if ($transactionDate === false) {
+					// Check for H24 time
+					$transactionDate = \DateTime::createFromFormat("m/d/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
+				}
+				if ($transactionDate === false) {
+					// Try to get only the date
+					$pos = strpos($dateString, ' ');
+					if ($pos !== false) {
+						$dateString = substr($dateString, 0, $pos);
+						$transactionDate = \DateTime::createFromFormat("m/d/y", trim($dateString));
+					}
+				}
+			} else
+				if ($this->_dateFormat == 'd/MM/yy') {
+					$transactionDate = \DateTime::createFromFormat("j/m/y H:i:s", \trim($dateString));
+				} else
+					if ($this->_dateFormat == 'tt.MM.uu') {
+						$transactionDate = \DateTime::createFromFormat("d.m.y H:i:s", \trim($dateString));
+					} else
+						if ($this->_dateFormat == 'jj-MM-aa') {
+							$transactionDate = \DateTime::createFromFormat("d-m-y H:i:s", \trim($dateString));
+						} else
+							if ($this->_dateFormat == 'jj/MM/aa') {
+								$transactionDate = \DateTime::createFromFormat("d/m/y H:i:s", \trim($dateString));
+							} else
+								if ($this->_dateFormat == 'dd.MM.yy') {
+									$transactionDate = \DateTime::createFromFormat("d.m.y H:i:s", \trim($dateString));
+								} else
+									if ($this->_dateFormat == 'yy-MM-dd') {
+										$transactionDate = \DateTime::createFromFormat("y-m-d H:i:s", \trim($dateString));
+									} else
+										if ($this->_dateFormat == 'd-M-yy') {
+											$transactionDate = \DateTime::createFromFormat("j-n-y H:i:s", \trim($dateString));
+										} else
+											if ($this->_dateFormat == 'yyyy/MM/dd') {
+												$transactionDate = \DateTime::createFromFormat("Y/m/d H:i:s", \trim($dateString));
+											} else
+												if ($this->_dateFormat == 'yyyy-MM-dd') {
+													$transactionDate = \DateTime::createFromFormat("Y-m-d H:i:s", \trim($dateString));
+												} else {
+													throw new \Exception("\n Date Format not supported " . $this->_dateFormat . "\n");
+												}
+		if ($transactionDate === false) {
+			throw new \Exception("TradeDoubler - Date Format not supported " . $this->_dateFormat . " for date: " . $dateString . "\n");
+		}
+		return $transactionDate;
+	}
 
-                    $transaction = Array();
-                    $transaction['merchantId'] = $transactionExportArray[2];
-                    $transactionDate = self::toDate(\substr($transactionExportArray[4], 0, -6));
-                    
-                    $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
-                    if ($transactionExportArray[8] != '') {
-                        $transaction['unique_id'] = \substr($transactionExportArray[8], 0, 200);
-                    } else
-                        if ($transactionExportArray[7] != '') {
-                            $transaction['unique_id'] = \substr($transactionExportArray[7], 0, 200);
-                        } else {
-                            throw new \Exception("No Identifier");
-                        }
+	/**
+	 * @return array
+	 * @throws \Exception
+	 * Attention ! OLD API connection
+	 */
+	public function getPaymentHistory()
+	{
+		$paymentHistory = array();
 
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/reportSelection/Payment?', array());
+		$exportReport = $this->_client->get($urls);
+		/*** load the html into the object ***/
+		$doc = new \DOMDocument();
+		\libxml_use_internal_errors(true);
+		$doc->validateOnParse = true;
+		$doc->loadHTML($exportReport[0]);
+		$selectList = $doc->getElementsByTagName('select');
+		$paymentSelect = null;
+		if ($selectList->length > 0) {
+			// looking for the payments select
+			$it = 0;
+			while ($it < $selectList->length) {
+				$selectName = $selectList->item($it)->attributes->getNamedItem('name')->nodeValue;
+				if ($selectName == 'payment_id') {
+					$paymentSelect = $selectList->item($it);
+					break;
+				}
+				$it++;
+			}
+			if ($paymentSelect != null) {
+				$paymentLines = $paymentSelect->childNodes;
+				for ($i = 0; $i < $paymentLines->length; $i++) {
+					$pid = $paymentLines->item($i)->attributes->getNamedItem("value")->nodeValue;
+					if (\is_numeric($pid)) {
+						$obj = array();
 
-                    if ($transactionExportArray[9] != '') {
-                        $transaction['custom_id'] = $transactionExportArray[9];
-                    }
+						$paymentLine = $paymentLines->item($i)->nodeValue;
+						$value = \preg_replace('/[^0-9\.,]/', "", \substr($paymentLine, 10));
 
-                    if ($transactionExportArray[11] == 'A') {
-                        $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-                    } else
-                        if ($transactionExportArray[11] == 'P') {
-                            $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-                        } else
-                            if ($transactionExportArray[11] == 'D') {
-                                $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-                            }
+						$paymentParts = \explode(" ", $paymentLine);
+						$date = self::toDate($paymentParts[0] . " 00:00:00");
 
-                    if ($transactionExportArray[19] != '') {
-                        $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[19]);
-                    } else {
-                        $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[20]);
-                    }
+						$obj['date'] = $date->format("Y-m-d H:i:s");
+						$obj['pid'] = $pid;
+						$obj['method'] = 'BACS';
+						$obj['value'] = \Oara\Utilities::parseDouble($value);
 
-                    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[20]);
-                    $totalTransactions[] = $transaction;
-                }
-            }
-        }
-        return $totalTransactions;
-    }
+						$paymentHistory[] = $obj;
+					}
+				}
+			}
+		}
+		return $paymentHistory;
+	}
 
-    /**
-     * @param $date
-     * @return string
-     * @throws Exception
-     */
-    protected function formatDate($date)
-    {
-        if ($this->_dateFormat == 'dd/MM/yy') {
-            $dateString = $date->format('d/m/Y');
-        } else
-            if ($this->_dateFormat == 'M/d/yy') {
-                $dateString = $date->format('n/j/y');
-            } else
-                if ($this->_dateFormat == 'd/MM/yy') {
-                    $dateString = $date->format('j/m/y');
-                } else
-                    if ($this->_dateFormat == 'tt.MM.uu') {
-                        $dateString = $date->format('d.m.y');
-                    } else
-                        if ($this->_dateFormat == 'jj-MM-aa') {
-                            $dateString = $date->format('d-m-y');
-                        } else
-                            if ($this->_dateFormat == 'jj/MM/aa') {
-                                $dateString = $date->format('d/m/y');
-                            } else
-                                if ($this->_dateFormat == 'dd.MM.yy') {
-                                    $dateString = $date->format('d.m.y');
-                                } else
-                                    if ($this->_dateFormat == 'yy-MM-dd') {
-                                        $dateString = $date->format('y-m-d');
-                                    } else
-                                        if ($this->_dateFormat == 'd-M-yy') {
-                                            $dateString = $date->format('j-n-y');
-                                        } else
-                                            if ($this->_dateFormat == 'yyyy/MM/dd') {
-                                                $dateString = $date->format('Y/m/d');
-                                            } else
-                                                if ($this->_dateFormat == 'yyyy-MM-dd') {
-                                                    $dateString = $date->format('Y-m-d');
-                                                } else {
-                                                    throw new \Exception("\n Date Format not supported " . $this->_dateFormat . "\n");
-                                                }
-        return $dateString;
-    }
+	/**
+	 * @param $paymentId
+	 * @return array
+	 * @throws \Exception
+	 * Attention ! OLD API connection
+	 */
+	public function paymentTransactions($paymentId)
+	{
+		$transactionList = array();
 
-    /**
-     * @param $dateString
-     * @return \DateTime|null
-     * @throws Exception
-     */
-    protected function toDate($dateString)
-    {
-        $transactionDate = false;
-        $hour_separator=':';
-        if (strlen($dateString)>10){
-            if (strpos(substr($dateString,10),'.')!==false){
-                $hour_separator='.';
-            }
-        }
-        if ($this->_dateFormat == 'dd/MM/yy') {
-            $transactionDate = \DateTime::createFromFormat("d/m/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
-        } else
-            if ($this->_dateFormat == 'M/d/yy') {
-                // Check for AM/PM time - 2019-04-15 <PN>
-                $transactionDate = \DateTime::createFromFormat("m/d/y h{$hour_separator}i{$hour_separator}s A", \trim($dateString));
-                if ($transactionDate === false) {
-                    // Check for H24 time
-                    $transactionDate = \DateTime::createFromFormat("m/d/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
-                }
-                if ($transactionDate === false) {
-                    // Try to get only the date
-                    $pos = strpos($dateString,' ');
-                    if ($pos !== false) {
-                        $dateString = substr($dateString, 0, $pos);
-                        $transactionDate = \DateTime::createFromFormat("m/d/y", trim($dateString));
-                    }
-                }
-            } else
-                if ($this->_dateFormat == 'd/MM/yy') {
-                    $transactionDate = \DateTime::createFromFormat("j/m/y H:i:s", \trim($dateString));
-                } else
-                    if ($this->_dateFormat == 'tt.MM.uu') {
-                        $transactionDate = \DateTime::createFromFormat("d.m.y H:i:s", \trim($dateString));
-                    } else
-                        if ($this->_dateFormat == 'jj-MM-aa') {
-                            $transactionDate = \DateTime::createFromFormat("d-m-y H:i:s", \trim($dateString));
-                        } else
-                            if ($this->_dateFormat == 'jj/MM/aa') {
-                                $transactionDate = \DateTime::createFromFormat("d/m/y H:i:s", \trim($dateString));
-                            } else
-                                if ($this->_dateFormat == 'dd.MM.yy') {
-                                    $transactionDate = \DateTime::createFromFormat("d.m.y H:i:s", \trim($dateString));
-                                } else
-                                    if ($this->_dateFormat == 'yy-MM-dd') {
-                                        $transactionDate = \DateTime::createFromFormat("y-m-d H:i:s", \trim($dateString));
-                                    } else
-                                        if ($this->_dateFormat == 'd-M-yy') {
-                                            $transactionDate = \DateTime::createFromFormat("j-n-y H:i:s", \trim($dateString));
-                                        } else
-                                            if ($this->_dateFormat == 'yyyy/MM/dd') {
-                                                $transactionDate = \DateTime::createFromFormat("Y/m/d H:i:s", \trim($dateString));
-                                            } else
-                                                if ($this->_dateFormat == 'yyyy-MM-dd') {
-                                                    $transactionDate = \DateTime::createFromFormat("Y-m-d H:i:s", \trim($dateString));
-                                                } else {
-                                                    throw new \Exception("\n Date Format not supported " . $this->_dateFormat . "\n");
-                                                }
-        if ($transactionDate === false) {
-            throw new \Exception("TradeDoubler - Date Format not supported " . $this->_dateFormat . " for date: " . $dateString . "\n");
-        }
-        return $transactionDate;
-    }
-
-    /**
-     * @return array
-     * @throws \Exception
-     */
-    public function getPaymentHistory()
-    {
-        $paymentHistory = array();
-
-        $urls = array();
-        $urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/reportSelection/Payment?', array());
-        $exportReport = $this->_client->get($urls);
-        /*** load the html into the object ***/
-        $doc = new \DOMDocument();
-        \libxml_use_internal_errors(true);
-        $doc->validateOnParse = true;
-        $doc->loadHTML($exportReport[0]);
-        $selectList = $doc->getElementsByTagName('select');
-        $paymentSelect = null;
-        if ($selectList->length > 0) {
-            // looking for the payments select
-            $it = 0;
-            while ($it < $selectList->length) {
-                $selectName = $selectList->item($it)->attributes->getNamedItem('name')->nodeValue;
-                if ($selectName == 'payment_id') {
-                    $paymentSelect = $selectList->item($it);
-                    break;
-                }
-                $it++;
-            }
-            if ($paymentSelect != null) {
-                $paymentLines = $paymentSelect->childNodes;
-                for ($i = 0; $i < $paymentLines->length; $i++) {
-                    $pid = $paymentLines->item($i)->attributes->getNamedItem("value")->nodeValue;
-                    if (\is_numeric($pid)) {
-                        $obj = array();
-
-                        $paymentLine = $paymentLines->item($i)->nodeValue;
-                        $value = \preg_replace('/[^0-9\.,]/', "", \substr($paymentLine, 10));
-
-                        $paymentParts = \explode(" ",$paymentLine);
-                        $date = self::toDate($paymentParts[0]." 00:00:00");
-
-                        $obj['date'] = $date->format("Y-m-d H:i:s");
-                        $obj['pid'] = $pid;
-                        $obj['method'] = 'BACS';
-                        $obj['value'] = \Oara\Utilities::parseDouble($value);
-
-                        $paymentHistory[] = $obj;
-                    }
-                }
-            }
-        }
-        return $paymentHistory;
-    }
-
-    /**
-     * @param $paymentId
-     * @return array
-     * @throws \Exception
-     */
-    public function paymentTransactions($paymentId)
-    {
-        $transactionList = array();
-
-        $urls = array();
-        $valuesFormExport = array();
-        $valuesFormExport[] = new \Oara\Curl\Parameter('popup', 'true');
-        $valuesFormExport[] = new \Oara\Curl\Parameter('payment_id', $paymentId);
-        $urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/reports/Payment.html?', $valuesFormExport);
-        $exportReport = $this->_client->get($urls);
+		$urls = array();
+		$valuesFormExport = array();
+		$valuesFormExport[] = new \Oara\Curl\Parameter('popup', 'true');
+		$valuesFormExport[] = new \Oara\Curl\Parameter('payment_id', $paymentId);
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/reports/Payment.html?', $valuesFormExport);
+		$exportReport = $this->_client->get($urls);
 
 
-        $dom = new \Zend\Dom\Query($exportReport[0]);
-        $results = $dom->execute('//a');
+		$dom = new \Zend\Dom\Query($exportReport[0]);
+		$results = $dom->execute('//a');
 
-        $urls = array();
-        foreach ($results as $result) {
-            $url = $result->getAttribute('href');
-            $urls[] = new \Oara\Curl\Request("http://publisher.tradedoubler.com" . $url . "&format=CSV", array());
-        }
-        $exportReportList = $this->_client->get($urls);
-        foreach ($exportReportList as $exportReport) {
-            $exportReportData = \str_getcsv($exportReport, "\r\n");
-            $num = \count($exportReportData);
-            for ($i = 2; $i < $num - 1; $i++) {
-                $transactionExportArray = \str_getcsv($exportReportData[$i], ";");
-                if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[2], $this->_sitesAllowed)) {
-                    $transaction = Array();
-                    $transaction['merchantId'] = $transactionExportArray[2];
-                    $transactionDate = self::toDate($transactionExportArray[6]);
-                    $transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
-                    if ($transactionExportArray[8] != '') {
-                        $transaction['unique_id'] = \substr($transactionExportArray[8], 0, 200);
-                    } else
-                        if ($transactionExportArray[7] != '') {
-                            $transaction['unique_id'] = \substr($transactionExportArray[7], 0, 200);
-                        } else {
-                            throw new \Exception("No Identifier");
-                        }
+		$urls = array();
+		foreach ($results as $result) {
+			$url = $result->getAttribute('href');
+			$urls[] = new \Oara\Curl\Request("http://publisher.tradedoubler.com" . $url . "&format=CSV", array());
+		}
+		$exportReportList = $this->_client->get($urls);
+		foreach ($exportReportList as $exportReport) {
+			$exportReportData = \str_getcsv($exportReport, "\r\n");
+			$num = \count($exportReportData);
+			for ($i = 2; $i < $num - 1; $i++) {
+				$transactionExportArray = \str_getcsv($exportReportData[$i], ";");
+				if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[2], $this->_sitesAllowed)) {
+					$transaction = Array();
+					$transaction['merchantId'] = $transactionExportArray[2];
+					$transactionDate = self::toDate($transactionExportArray[6]);
+					$transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
+					if ($transactionExportArray[8] != '') {
+						$transaction['unique_id'] = \substr($transactionExportArray[8], 0, 200);
+					} else
+						if ($transactionExportArray[7] != '') {
+							$transaction['unique_id'] = \substr($transactionExportArray[7], 0, 200);
+						} else {
+							throw new \Exception("No Identifier");
+						}
 
 
-                    if ($transactionExportArray[9] != '') {
-                        $transaction['custom_id'] = $transactionExportArray[9];
-                    }
+					if ($transactionExportArray[9] != '') {
+						$transaction['custom_id'] = $transactionExportArray[9];
+					}
 
-                    if ($transactionExportArray[11] == 'A') {
-                        $transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
-                    } else
-                        if ($transactionExportArray[11] == 'P') {
-                            $transaction['status'] = \Oara\Utilities::STATUS_PENDING;
-                        } else
-                            if ($transactionExportArray[11] == 'D') {
-                                $transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
-                            }
+					if ($transactionExportArray[11] == 'A') {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} else
+						if ($transactionExportArray[11] == 'P') {
+							$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						} else
+							if ($transactionExportArray[11] == 'D') {
+								$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+							}
 
-                    if ($transactionExportArray[13] != '') {
-                        $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[13]);
-                    } else {
-                        $transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[14]);
-                    }
+					if ($transactionExportArray[13] != '') {
+						$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[13]);
+					} else {
+						$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[14]);
+					}
 
-                    $transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[15]);
-                    $transactionList[] = $transaction;
-                }
-            }
-        }
+					$transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[15]);
+					$transactionList[] = $transaction;
+				}
+			}
+		}
 
-        return $transactionList;
-    }
+		return $transactionList;
+	}
 }

--- a/Oara/Network/Publisher/TradeDoublerWhitelabel.php
+++ b/Oara/Network/Publisher/TradeDoublerWhitelabel.php
@@ -1,0 +1,717 @@
+<?php
+namespace Oara\Network\Publisher;
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+/**
+ * Export Class
+ *
+ * @author     Carlos Morillo Merino
+ * @category   Td
+ * @copyright  Fubra Limited
+ * @version    Release: 01.00
+ *
+ */
+class TradeDoublerWhitelabel extends \Oara\Network
+{
+
+	protected $_sitesAllowed = array();
+	protected $_client = null;
+	protected $_dateFormat = null;
+
+	public function login($credentials)
+	{
+
+		$this->_credentials = $credentials;
+		$this->_client = new \Oara\Curl\Access($credentials);
+
+		$user = $this->_credentials['user'];
+		$password = $this->_credentials['password'];
+		$loginUrl = 'http://publisher.tradedoubler.com/pan/login';
+
+		$valuesLogin = array(new \Oara\Curl\Parameter('j_username', $user),
+			new \Oara\Curl\Parameter('j_password', $password)
+		);
+
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request($loginUrl, $valuesLogin);
+		$this->_client->post($urls);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
+
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
+
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials["password"] = $parameter;
+
+		return $credentials;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = false;
+
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
+		$exportReport = $this->_client->get($urls);
+
+		if (\preg_match('/\(([a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4})\)/', $exportReport[0], $match)) {
+			$this->_dateFormat = $match[1];
+		}
+
+
+		if ($this->_dateFormat != null) {
+			$connection = true;
+		}
+		return $connection;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getMerchantList()
+	{
+		$merchantReportList = self::getMerchantReportList();
+		$merchants = Array();
+		foreach ($merchantReportList as $key => $value) {
+			$obj = Array();
+			$obj['cid'] = $key;
+			$obj['name'] = $value;
+			$merchants[] = $obj;
+		}
+
+		return $merchants;
+	}
+
+	/**
+	 * It returns an array with the different merchants
+	 * @return array
+	 */
+	private function getMerchantReportList()
+	{
+
+		$valuesFormExport = array(new \Oara\Curl\Parameter('reportName', 'aAffiliateMyProgramsReport'),
+			new \Oara\Curl\Parameter('tabMenuName', ''),
+			new \Oara\Curl\Parameter('isPostBack', ''),
+			new \Oara\Curl\Parameter('showAdvanced', 'true'),
+			new \Oara\Curl\Parameter('showFavorite', 'false'),
+			new \Oara\Curl\Parameter('run_as_organization_id', ''),
+			new \Oara\Curl\Parameter('minRelativeIntervalStartTime', '0'),
+			new \Oara\Curl\Parameter('maxIntervalSize', '0'),
+			new \Oara\Curl\Parameter('interval', 'MONTHS'),
+			new \Oara\Curl\Parameter('reportPrograms', ''),
+			new \Oara\Curl\Parameter('reportTitleTextKey', 'REPORT3_SERVICE_REPORTS_AAFFILIATEMYPROGRAMSREPORT_TITLE'),
+			new \Oara\Curl\Parameter('setColumns', 'true'),
+			new \Oara\Curl\Parameter('latestDayToExecute', '0'),
+			new \Oara\Curl\Parameter('affiliateId', ''),
+			new \Oara\Curl\Parameter('includeWarningColumn', 'true'),
+			new \Oara\Curl\Parameter('sortBy', 'orderDefault'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'programId'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'affiliateId'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'applicationDate'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'status'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'useMetricColumn'),
+			new \Oara\Curl\Parameter('customKeyMetricCount', '0'),
+			new \Oara\Curl\Parameter('metric1.name', ''),
+			new \Oara\Curl\Parameter('metric1.midFactor', ''),
+			new \Oara\Curl\Parameter('metric1.midOperator', '/'),
+			new \Oara\Curl\Parameter('metric1.columnName1', 'programId'),
+			new \Oara\Curl\Parameter('metric1.operator1', '/'),
+			new \Oara\Curl\Parameter('metric1.columnName2', 'programId'),
+			new \Oara\Curl\Parameter('metric1.lastOperator', '/'),
+			new \Oara\Curl\Parameter('metric1.factor', ''),
+			new \Oara\Curl\Parameter('metric1.summaryType', 'NONE'),
+			new \Oara\Curl\Parameter('format', 'CSV'),
+			new \Oara\Curl\Parameter('separator', ','),
+			new \Oara\Curl\Parameter('dateType', '0'),
+			new \Oara\Curl\Parameter('favoriteId', ''),
+			new \Oara\Curl\Parameter('favoriteName', ''),
+			new \Oara\Curl\Parameter('favoriteDescription', ''),
+			new \Oara\Curl\Parameter('programAffiliateStatusId', '3')
+		);
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Internal.action?', $valuesFormExport);
+		$exportReport = $this->_client->post($urls);
+		$exportReport[0] = self::checkReportError($exportReport[0], $urls[0]);
+		$merchantReportList = self::getExportMerchantReport($exportReport[0]);
+
+		$valuesFormExport = array(new \Oara\Curl\Parameter('reportName', 'aAffiliateMyProgramsReport'),
+			new \Oara\Curl\Parameter('tabMenuName', ''),
+			new \Oara\Curl\Parameter('isPostBack', ''),
+			new \Oara\Curl\Parameter('showAdvanced', 'true'),
+			new \Oara\Curl\Parameter('showFavorite', 'false'),
+			new \Oara\Curl\Parameter('run_as_organization_id', ''),
+			new \Oara\Curl\Parameter('minRelativeIntervalStartTime', '0'),
+			new \Oara\Curl\Parameter('maxIntervalSize', '0'),
+			new \Oara\Curl\Parameter('interval', 'MONTHS'),
+			new \Oara\Curl\Parameter('reportPrograms', ''),
+			new \Oara\Curl\Parameter('reportTitleTextKey', 'REPORT3_SERVICE_REPORTS_AAFFILIATEMYPROGRAMSREPORT_TITLE'),
+			new \Oara\Curl\Parameter('setColumns', 'true'),
+			new \Oara\Curl\Parameter('latestDayToExecute', '0'),
+			new \Oara\Curl\Parameter('affiliateId', ''),
+			new \Oara\Curl\Parameter('includeWarningColumn', 'true'),
+			new \Oara\Curl\Parameter('sortBy', 'orderDefault'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'programId'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'affiliateId'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'applicationDate'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'columns'),
+			new \Oara\Curl\Parameter('columns', 'status'),
+			new \Oara\Curl\Parameter('autoCheckbox', 'useMetricColumn'),
+			new \Oara\Curl\Parameter('customKeyMetricCount', '0'),
+			new \Oara\Curl\Parameter('metric1.name', ''),
+			new \Oara\Curl\Parameter('metric1.midFactor', ''),
+			new \Oara\Curl\Parameter('metric1.midOperator', '/'),
+			new \Oara\Curl\Parameter('metric1.columnName1', 'programId'),
+			new \Oara\Curl\Parameter('metric1.operator1', '/'),
+			new \Oara\Curl\Parameter('metric1.columnName2', 'programId'),
+			new \Oara\Curl\Parameter('metric1.lastOperator', '/'),
+			new \Oara\Curl\Parameter('metric1.factor', ''),
+			new \Oara\Curl\Parameter('metric1.summaryType', 'NONE'),
+			new \Oara\Curl\Parameter('format', 'CSV'),
+			new \Oara\Curl\Parameter('separator', ','),
+			new \Oara\Curl\Parameter('dateType', '0'),
+			new \Oara\Curl\Parameter('favoriteId', ''),
+			new \Oara\Curl\Parameter('favoriteName', ''),
+			new \Oara\Curl\Parameter('favoriteDescription', ''),
+			new \Oara\Curl\Parameter('programAffiliateStatusId', '4')
+		);
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Internal.action?', $valuesFormExport);
+		$exportReport = $this->_client->post($urls);
+		$exportReport[0] = self::checkReportError($exportReport[0], $urls[0]);
+		$merchantReportListAux = self::getExportMerchantReport($exportReport[0]);
+		foreach ($merchantReportListAux as $key => $value) {
+			$merchantReportList[$key] = $value;
+		}
+		return $merchantReportList;
+	}
+
+	public function checkReportError($content, $request, $try = 0)
+	{
+
+		if (\preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
+			//report too big, we have to download it and read it
+			if (\preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
+
+				$file = "http://publisher.tradedoubler.com" . $matches[0];
+				$newfile = \realpath(\dirname(COOKIES_BASE_DIR)) . '/pdf/' . $matches[2] . '.zip';
+
+				if (!\copy($file, $newfile)) {
+					throw new \Exception('Failing copying the zip file \n\n');
+				}
+				$zip = new \ZipArchive();
+				if ($zip->open($newfile, \ZIPARCHIVE::CREATE) !== TRUE) {
+					throw new \Exception('Cannot open zip file \n\n');
+				}
+				$zip->extractTo(\realpath(\dirname(COOKIES_BASE_DIR)) . '/pdf/');
+				$zip->close();
+
+				$unzipFilePath = \realpath(\dirname(COOKIES_BASE_DIR)) . '/pdf/' . $matches[2];
+				$fileContent = \file_get_contents($unzipFilePath);
+				\unlink($newfile);
+				\unlink($unzipFilePath);
+				return $fileContent;
+			}
+
+			throw new \Exception('Report too big \n\n');
+
+		} else
+			if (\preg_match("/ error/", $content, $matches)) {
+				$urls = array();
+				$urls[] = $request;
+				$exportReport = $this->_client->get($urls);
+				$try++;
+				if ($try < 5) {
+					return self::checkReportError($exportReport[0], $request, $try);
+				} else {
+					throw new \Exception('Problem checking report\n\n');
+				}
+
+			} else {
+				return $content;
+			}
+
+	}
+
+	/**
+	 * @param $content
+	 * @return array
+	 */
+	private function getExportMerchantReport($content)
+	{
+
+		$merchantReport = self::formatCsv($content);
+
+		$exportData = \str_getcsv($merchantReport, "\r\n");
+		$merchantReportList = Array();
+		$num = \count($exportData);
+		$websiteMap = array();
+		for ($i = 3; $i < $num; $i++) {
+			$merchantExportArray = \str_getcsv($exportData[$i], ",");
+
+			if ($merchantExportArray[2] != '' && $merchantExportArray[4] != '') {
+				$merchantReportList[$merchantExportArray[4]] = $merchantExportArray[2];
+				$websiteMap[$merchantExportArray[0]] = "";
+			}
+
+		}
+		return $merchantReportList;
+	}
+
+	/**
+	 * @param $csv
+	 * @return mixed
+	 */
+	private function formatCsv($csv)
+	{
+		\preg_match_all("/\"([^\"]+?)\",/", $csv, $matches);
+		foreach ($matches[1] as $match) {
+			if (\preg_match("/,/", $match)) {
+				$rep = \preg_replace("/,/", "", $match);
+				$csv = \str_replace($match, $rep, $csv);
+				$match = $rep;
+			}
+			if (\preg_match("/\n/", $match)) {
+				$rep = \preg_replace("/\n/", "", $match);
+				$csv = \str_replace($match, $rep, $csv);
+			}
+		}
+		return $csv;
+	}
+
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		$merchantIdList = \Oara\Utilities::getMerchantIdMapFromMerchantList($merchantList);
+
+		$totalTransactions = Array();
+		$valuesFormExport = array(new \Oara\Curl\Parameter('reportName', 'aAffiliateEventBreakdownReport'),
+			new \Oara\Curl\Parameter('columns', 'programId'),
+			new \Oara\Curl\Parameter('columns', 'timeOfVisit'),
+			new \Oara\Curl\Parameter('columns', 'timeOfEvent'),
+			new \Oara\Curl\Parameter('columns', 'timeInSession'),
+			new \Oara\Curl\Parameter('columns', 'lastModified'),
+			new \Oara\Curl\Parameter('columns', 'epi1'),
+			new \Oara\Curl\Parameter('columns', 'eventName'),
+			new \Oara\Curl\Parameter('columns', 'pendingStatus'),
+			new \Oara\Curl\Parameter('columns', 'siteName'),
+			new \Oara\Curl\Parameter('columns', 'graphicalElementName'),
+			new \Oara\Curl\Parameter('columns', 'graphicalElementId'),
+			new \Oara\Curl\Parameter('columns', 'productName'),
+			new \Oara\Curl\Parameter('columns', 'productNrOf'),
+			new \Oara\Curl\Parameter('columns', 'productValue'),
+			new \Oara\Curl\Parameter('columns', 'affiliateCommission'),
+			new \Oara\Curl\Parameter('columns', 'link'),
+			new \Oara\Curl\Parameter('columns', 'leadNR'),
+			new \Oara\Curl\Parameter('columns', 'orderNR'),
+			new \Oara\Curl\Parameter('columns', 'pendingReason'),
+			new \Oara\Curl\Parameter('columns', 'orderValue'),
+			new \Oara\Curl\Parameter('isPostBack', ''),
+			new \Oara\Curl\Parameter('metric1.lastOperator', '/'),
+			new \Oara\Curl\Parameter('interval', ''),
+			new \Oara\Curl\Parameter('favoriteDescription', ''),
+			new \Oara\Curl\Parameter('event_id', '0'),
+			new \Oara\Curl\Parameter('pending_status', '1'),
+			new \Oara\Curl\Parameter('run_as_organization_id', ''),
+			new \Oara\Curl\Parameter('minRelativeIntervalStartTime', '0'),
+			new \Oara\Curl\Parameter('includeWarningColumn', 'true'),
+			new \Oara\Curl\Parameter('metric1.summaryType', 'NONE'),
+			new \Oara\Curl\Parameter('metric1.operator1', '/'),
+			new \Oara\Curl\Parameter('latestDayToExecute', '0'),
+			new \Oara\Curl\Parameter('showAdvanced', 'true'),
+			new \Oara\Curl\Parameter('breakdownOption', '1'),
+			new \Oara\Curl\Parameter('metric1.midFactor', ''),
+			new \Oara\Curl\Parameter('reportTitleTextKey', 'REPORT3_SERVICE_REPORTS_AAFFILIATEEVENTBREAKDOWNREPORT_TITLE'),
+			new \Oara\Curl\Parameter('setColumns', 'true'),
+			new \Oara\Curl\Parameter('metric1.columnName1', 'orderValue'),
+			new \Oara\Curl\Parameter('metric1.columnName2', 'orderValue'),
+			new \Oara\Curl\Parameter('reportPrograms', ''),
+			new \Oara\Curl\Parameter('metric1.midOperator', '/'),
+			new \Oara\Curl\Parameter('dateSelectionType', '1'),
+			new \Oara\Curl\Parameter('favoriteName', ''),
+			new \Oara\Curl\Parameter('affiliateId', ''),
+			new \Oara\Curl\Parameter('dateType', '1'),
+			new \Oara\Curl\Parameter('period', 'custom_period'),
+			new \Oara\Curl\Parameter('tabMenuName', ''),
+			new \Oara\Curl\Parameter('maxIntervalSize', '0'),
+			new \Oara\Curl\Parameter('favoriteId', ''),
+			new \Oara\Curl\Parameter('sortBy', 'timeOfEvent'),
+			new \Oara\Curl\Parameter('metric1.name', ''),
+			new \Oara\Curl\Parameter('customKeyMetricCount', '0'),
+			new \Oara\Curl\Parameter('metric1.factor', ''),
+			new \Oara\Curl\Parameter('showFavorite', 'false'),
+			new \Oara\Curl\Parameter('separator', ','),
+			new \Oara\Curl\Parameter('format', 'CSV')
+		);
+		$valuesFormExport[] = new \Oara\Curl\Parameter('startDate', self::formatDate($dStartDate));
+		$valuesFormExport[] = new \Oara\Curl\Parameter('endDate', self::formatDate($dEndDate));
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/aReport3Internal.action?', $valuesFormExport);
+		$exportReport = $this->_client->get($urls);
+
+		$exportReport[0] = self::checkReportError($exportReport[0], $urls[0]);
+		$exportData = \str_getcsv($exportReport[0], "\r\n");
+		$num = \count($exportData);
+		for ($i = 2; $i < $num - 1; $i++) {
+
+			$transactionExportArray = \str_getcsv($exportData[$i], ",");
+
+			if (!isset($transactionExportArray[2])) {
+				throw new \Exception('Problem getting transaction\n\n');
+			}
+			if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[13], $this->_sitesAllowed)) {
+
+
+				if ($transactionExportArray[0] !== '' && isset($merchantIdList[(int)$transactionExportArray[2]])) {
+
+					$transaction = Array();
+					$transaction['merchantId'] = $transactionExportArray[2];
+					$transactionDate = self::toDate(\substr($transactionExportArray[4], 0, -6));
+
+					$transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
+					if ($transactionExportArray[8] != '') {
+						$transaction['unique_id'] = \substr($transactionExportArray[8], 0, 200);
+					} else
+						if ($transactionExportArray[7] != '') {
+							$transaction['unique_id'] = \substr($transactionExportArray[7], 0, 200);
+						} else {
+							throw new \Exception("No Identifier");
+						}
+
+
+					if ($transactionExportArray[9] != '') {
+						$transaction['custom_id'] = $transactionExportArray[9];
+					}
+
+					if ($transactionExportArray[11] == 'A') {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} else
+						if ($transactionExportArray[11] == 'P') {
+							$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						} else
+							if ($transactionExportArray[11] == 'D') {
+								$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+							}
+
+					if ($transactionExportArray[19] != '') {
+						$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[19]);
+					} else {
+						$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[20]);
+					}
+
+					$transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[20]);
+					$totalTransactions[] = $transaction;
+				}
+			}
+		}
+		return $totalTransactions;
+	}
+
+	/**
+	 * @param $date
+	 * @return string
+	 * @throws Exception
+	 */
+	protected function formatDate($date)
+	{
+		if ($this->_dateFormat == 'dd/MM/yy') {
+			$dateString = $date->format('d/m/Y');
+		} else
+			if ($this->_dateFormat == 'M/d/yy') {
+				$dateString = $date->format('n/j/y');
+			} else
+				if ($this->_dateFormat == 'd/MM/yy') {
+					$dateString = $date->format('j/m/y');
+				} else
+					if ($this->_dateFormat == 'tt.MM.uu') {
+						$dateString = $date->format('d.m.y');
+					} else
+						if ($this->_dateFormat == 'jj-MM-aa') {
+							$dateString = $date->format('d-m-y');
+						} else
+							if ($this->_dateFormat == 'jj/MM/aa') {
+								$dateString = $date->format('d/m/y');
+							} else
+								if ($this->_dateFormat == 'dd.MM.yy') {
+									$dateString = $date->format('d.m.y');
+								} else
+									if ($this->_dateFormat == 'yy-MM-dd') {
+										$dateString = $date->format('y-m-d');
+									} else
+										if ($this->_dateFormat == 'd-M-yy') {
+											$dateString = $date->format('j-n-y');
+										} else
+											if ($this->_dateFormat == 'yyyy/MM/dd') {
+												$dateString = $date->format('Y/m/d');
+											} else
+												if ($this->_dateFormat == 'yyyy-MM-dd') {
+													$dateString = $date->format('Y-m-d');
+												} else {
+													throw new \Exception("\n Date Format not supported " . $this->_dateFormat . "\n");
+												}
+		return $dateString;
+	}
+
+	/**
+	 * @param $dateString
+	 * @return \DateTime|null
+	 * @throws Exception
+	 */
+	protected function toDate($dateString)
+	{
+		$transactionDate = false;
+		$hour_separator=':';
+		if (strlen($dateString)>10){
+			if (strpos(substr($dateString,10),'.')!==false){
+				$hour_separator='.';
+			}
+		}
+		if ($this->_dateFormat == 'dd/MM/yy') {
+			$transactionDate = \DateTime::createFromFormat("d/m/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
+		} else
+			if ($this->_dateFormat == 'M/d/yy') {
+				// Check for AM/PM time - 2019-04-15 <PN>
+				$transactionDate = \DateTime::createFromFormat("m/d/y h{$hour_separator}i{$hour_separator}s A", \trim($dateString));
+				if ($transactionDate === false) {
+					// Check for H24 time
+					$transactionDate = \DateTime::createFromFormat("m/d/y H{$hour_separator}i{$hour_separator}s", \trim($dateString));
+				}
+				if ($transactionDate === false) {
+					// Try to get only the date
+					$pos = strpos($dateString,' ');
+					if ($pos !== false) {
+						$dateString = substr($dateString, 0, $pos);
+						$transactionDate = \DateTime::createFromFormat("m/d/y", trim($dateString));
+					}
+				}
+			} else
+				if ($this->_dateFormat == 'd/MM/yy') {
+					$transactionDate = \DateTime::createFromFormat("j/m/y H:i:s", \trim($dateString));
+				} else
+					if ($this->_dateFormat == 'tt.MM.uu') {
+						$transactionDate = \DateTime::createFromFormat("d.m.y H:i:s", \trim($dateString));
+					} else
+						if ($this->_dateFormat == 'jj-MM-aa') {
+							$transactionDate = \DateTime::createFromFormat("d-m-y H:i:s", \trim($dateString));
+						} else
+							if ($this->_dateFormat == 'jj/MM/aa') {
+								$transactionDate = \DateTime::createFromFormat("d/m/y H:i:s", \trim($dateString));
+							} else
+								if ($this->_dateFormat == 'dd.MM.yy') {
+									$transactionDate = \DateTime::createFromFormat("d.m.y H:i:s", \trim($dateString));
+								} else
+									if ($this->_dateFormat == 'yy-MM-dd') {
+										$transactionDate = \DateTime::createFromFormat("y-m-d H:i:s", \trim($dateString));
+									} else
+										if ($this->_dateFormat == 'd-M-yy') {
+											$transactionDate = \DateTime::createFromFormat("j-n-y H:i:s", \trim($dateString));
+										} else
+											if ($this->_dateFormat == 'yyyy/MM/dd') {
+												$transactionDate = \DateTime::createFromFormat("Y/m/d H:i:s", \trim($dateString));
+											} else
+												if ($this->_dateFormat == 'yyyy-MM-dd') {
+													$transactionDate = \DateTime::createFromFormat("Y-m-d H:i:s", \trim($dateString));
+												} else {
+													throw new \Exception("\n Date Format not supported " . $this->_dateFormat . "\n");
+												}
+		if ($transactionDate === false) {
+			throw new \Exception("TradeDoubler - Date Format not supported " . $this->_dateFormat . " for date: " . $dateString . "\n");
+		}
+		return $transactionDate;
+	}
+
+	/**
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getPaymentHistory()
+	{
+		$paymentHistory = array();
+
+		$urls = array();
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/reportSelection/Payment?', array());
+		$exportReport = $this->_client->get($urls);
+		/*** load the html into the object ***/
+		$doc = new \DOMDocument();
+		\libxml_use_internal_errors(true);
+		$doc->validateOnParse = true;
+		$doc->loadHTML($exportReport[0]);
+		$selectList = $doc->getElementsByTagName('select');
+		$paymentSelect = null;
+		if ($selectList->length > 0) {
+			// looking for the payments select
+			$it = 0;
+			while ($it < $selectList->length) {
+				$selectName = $selectList->item($it)->attributes->getNamedItem('name')->nodeValue;
+				if ($selectName == 'payment_id') {
+					$paymentSelect = $selectList->item($it);
+					break;
+				}
+				$it++;
+			}
+			if ($paymentSelect != null) {
+				$paymentLines = $paymentSelect->childNodes;
+				for ($i = 0; $i < $paymentLines->length; $i++) {
+					$pid = $paymentLines->item($i)->attributes->getNamedItem("value")->nodeValue;
+					if (\is_numeric($pid)) {
+						$obj = array();
+
+						$paymentLine = $paymentLines->item($i)->nodeValue;
+						$value = \preg_replace('/[^0-9\.,]/', "", \substr($paymentLine, 10));
+
+						$paymentParts = \explode(" ",$paymentLine);
+						$date = self::toDate($paymentParts[0]." 00:00:00");
+
+						$obj['date'] = $date->format("Y-m-d H:i:s");
+						$obj['pid'] = $pid;
+						$obj['method'] = 'BACS';
+						$obj['value'] = \Oara\Utilities::parseDouble($value);
+
+						$paymentHistory[] = $obj;
+					}
+				}
+			}
+		}
+		return $paymentHistory;
+	}
+
+	/**
+	 * @param $paymentId
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function paymentTransactions($paymentId)
+	{
+		$transactionList = array();
+
+		$urls = array();
+		$valuesFormExport = array();
+		$valuesFormExport[] = new \Oara\Curl\Parameter('popup', 'true');
+		$valuesFormExport[] = new \Oara\Curl\Parameter('payment_id', $paymentId);
+		$urls[] = new \Oara\Curl\Request('http://publisher.tradedoubler.com/pan/reports/Payment.html?', $valuesFormExport);
+		$exportReport = $this->_client->get($urls);
+
+
+		$dom = new \Zend\Dom\Query($exportReport[0]);
+		$results = $dom->execute('//a');
+
+		$urls = array();
+		foreach ($results as $result) {
+			$url = $result->getAttribute('href');
+			$urls[] = new \Oara\Curl\Request("http://publisher.tradedoubler.com" . $url . "&format=CSV", array());
+		}
+		$exportReportList = $this->_client->get($urls);
+		foreach ($exportReportList as $exportReport) {
+			$exportReportData = \str_getcsv($exportReport, "\r\n");
+			$num = \count($exportReportData);
+			for ($i = 2; $i < $num - 1; $i++) {
+				$transactionExportArray = \str_getcsv($exportReportData[$i], ";");
+				if (\count($this->_sitesAllowed) == 0 || \in_array($transactionExportArray[2], $this->_sitesAllowed)) {
+					$transaction = Array();
+					$transaction['merchantId'] = $transactionExportArray[2];
+					$transactionDate = self::toDate($transactionExportArray[6]);
+					$transaction['date'] = $transactionDate->format("Y-m-d H:i:s");
+					if ($transactionExportArray[8] != '') {
+						$transaction['unique_id'] = \substr($transactionExportArray[8], 0, 200);
+					} else
+						if ($transactionExportArray[7] != '') {
+							$transaction['unique_id'] = \substr($transactionExportArray[7], 0, 200);
+						} else {
+							throw new \Exception("No Identifier");
+						}
+
+
+					if ($transactionExportArray[9] != '') {
+						$transaction['custom_id'] = $transactionExportArray[9];
+					}
+
+					if ($transactionExportArray[11] == 'A') {
+						$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+					} else
+						if ($transactionExportArray[11] == 'P') {
+							$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+						} else
+							if ($transactionExportArray[11] == 'D') {
+								$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+							}
+
+					if ($transactionExportArray[13] != '') {
+						$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[13]);
+					} else {
+						$transaction['amount'] = \Oara\Utilities::parseDouble($transactionExportArray[14]);
+					}
+
+					$transaction['commission'] = \Oara\Utilities::parseDouble($transactionExportArray[15]);
+					$transactionList[] = $transaction;
+				}
+			}
+		}
+
+		return $transactionList;
+	}
+}

--- a/Oara/Network/Publisher/VerticalAds.php
+++ b/Oara/Network/Publisher/VerticalAds.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Oara\Network\Publisher;
+
+use Oara\Utilities;
+
+/**
+ * The goal of the Open Affiliate Report Aggregator (OARA) is to develop a set
+ * of PHP classes that can download affiliate reports from a number of affiliate networks, and store the data in a common format.
+ *
+ * Copyright (C) 2016  Fubra Limited
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact
+ * ------------
+ * Fubra Limited <support@fubra.com> , +44 (0)1252 367 200
+ **/
+class VerticalAds extends \Oara\Network
+{
+	private $_credentials = null;
+
+
+	/**
+	 * @param $credentials
+	 * @throws Exception
+	 */
+	public function login($credentials)
+	{
+		$this->_credentials = $credentials;
+
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function getNeededCredentials()
+	{
+		$credentials = array();
+
+		$parameter = array();
+		$parameter["description"] = "User Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "User";
+		$credentials["user"] = $parameter;
+
+		$parameter = array();
+		$parameter["description"] = "Password to Log in";
+		$parameter["required"] = true;
+		$parameter["name"] = "Password";
+		$credentials[] = $parameter;
+
+		return $credentials;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function checkConnection()
+	{
+		$connection = true;
+		return $connection;
+	}
+
+
+	/**
+	 * @param null $merchantList
+	 * @param \DateTime|null $dStartDate
+	 * @param \DateTime|null $dEndDate
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTransactionList($merchantList = null, \DateTime $dStartDate = null, \DateTime $dEndDate = null)
+	{
+		/**
+		 * See: https://data.verticalads.net/account/docs/verticalAds-Zentrale-Publisher-Schnittstelle-v1.3.pdf
+		 * https://data.verticalads.net/api/general/v1.3/api.php?user=USERNAME&key=KEY&network=NETWORK
+		 * Returns the result in the JSON format (default format)
+		 */
+		$totalTransactions = array();
+		try {
+			$user = $this->_credentials['user'];
+			$password = $this->_credentials['password'];
+			$id_site = $this->_credentials['idSite'];
+			$a_dates = array();
+
+			if (empty($dStartDate) || empty($dEndDate)) {
+				throw new \Exception("[VerticalAds][getTransactionList] Date required. Max request time frame is 31 days");
+			}
+			$interval = $dStartDate->diff($dEndDate);
+			$interval_in_days = $interval->days;
+			if ($interval_in_days > 30) {
+				//Create groups of dates, Get transactions grouping by dates. Max request time frame is 31 days.
+				$auxStartDate = clone $dStartDate;
+				$auxDate = $auxStartDate->modify("+ 30 days");
+				while ($dEndDate > $auxDate) {
+					$a_dates[] = array($dStartDate, $auxDate);
+					$dStartDate = clone $auxDate;
+					$auxStartDate = clone $auxDate;
+					$auxDate = $auxStartDate->modify("+ 30 days");
+					if ($auxDate > $dEndDate) {
+						$auxDate = $dEndDate;
+						$a_dates[] = array($dStartDate, $auxDate);
+					}
+				}
+			} else {
+				$a_dates[] = array($dStartDate, $dEndDate);
+			}
+			foreach ($a_dates as $dates) {
+				$dStartDate = $dates[0];
+				$dEndDate = $dates[1];
+
+				$transactions = "https://data.verticalads.net/api/general/v1.3/api.php";
+				$params = array(
+					new \Oara\Curl\Parameter('network', $id_site),
+					new \Oara\Curl\Parameter('user', $user),
+					new \Oara\Curl\Parameter('key', $password),
+					new \Oara\Curl\Parameter('startDateConversion', $dStartDate->format('Y-m-d')),
+					new \Oara\Curl\Parameter('endDateConversion', $dEndDate->format('Y-m-d')),
+				);
+
+				$p = array();
+				foreach ($params as $parameter) {
+					$p[] = $parameter->getKey() . '=' . \urlencode($parameter->getValue());
+				}
+				$get_params = implode('&', $p);
+
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_URL, $transactions . '?' . $get_params);
+				curl_setopt($ch, CURLOPT_POST, false);
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+
+				$curl_results = curl_exec($ch);
+				curl_close($ch);
+				if (false == $curl_results || strpos($curl_results, 'error') !== false) {
+					throw new \Exception('[VerticalAds][getTransactionList][Exception] Invalid response, results: ' . $curl_results);
+				}
+				$transactionsList = json_decode($curl_results, true);
+
+				if (isset($transactionsList['conversions'])) {
+					$n_transactions = count($transactionsList['conversions']);
+					if ($n_transactions > 0) {
+						if (isset($transactionsList['summary']['totalConversionsCount']) && $n_transactions !== $transactionsList['summary']['totalConversionsCount']) {
+							throw new \Exception("[VerticalAds][getTransactionList][Exception] Check the number of transactions. totalConversionsCount: " . $transactionsList['summary']['totalConversionsCount']
+								. ' conversions: ' . $n_transactions);
+						}
+						foreach ($transactionsList['conversions'] as $transactionJson) {
+
+							$a_transaction = self::createTransactionArray($transactionJson);
+							$totalTransactions[] = $a_transaction;
+						}
+					}
+				} else {
+					throw new \Exception("[VerticalAds][getTransactionList][Exception] " . $transactionsList);
+				}
+			}
+		} catch (\Exception $e) {
+			throw new \Exception($e);
+		}
+
+		return $totalTransactions;
+
+	}
+
+	public function createTransactionArray($transactionJson)
+	{
+
+		$transaction = Array();
+		$transaction['unique_id'] = $transactionJson['networkOrderId'];
+		$transaction['merchantId'] = $transactionJson['networkCampaignId'];
+		$transaction['merchantName'] = $transactionJson['networkCampaignName'];
+		$transaction['date'] = $transactionJson['networkDateTimeConversion'];
+		$transaction['click_date'] = $transactionJson['networkDateTimeClick'] ?: null;
+		$transaction['update_date'] = $transactionJson['networkDateTimeLastUpdated'] ?: null;
+		$transaction['amount'] = \Oara\Utilities::parseDouble($transactionJson['turnover']);
+		$transaction['commission'] = \Oara\Utilities::parseDouble($transactionJson['commission']);
+		$transaction['currency'] = $transactionJson['networkCurrency'];
+		//subid
+		$transaction['custom_id'] = $transactionJson['networkAdspaceSubid'] ?: null;
+		$transaction['title'] = $transactionJson['networkConversionTypeName'];
+		$transaction['action'] = null;
+
+		switch ($transactionJson['status']) {
+			case 'PENDING':
+				$transaction['status'] = \Oara\Utilities::STATUS_PENDING;
+				break;
+			case 'CANCELED':
+				$transaction['status'] = \Oara\Utilities::STATUS_DECLINED;
+				break;
+			case 'APPROVED':
+				$transaction['status'] = \Oara\Utilities::STATUS_CONFIRMED;
+				break;
+		}
+		switch ($transactionJson['conversionType']) {
+			case 'LEAD':
+				$transaction['action'] = \Oara\Utilities::TYPE_LEAD;
+				break;
+			case 'SALEFIX':
+			case 'SALEVAR':
+				$transaction['action'] = \Oara\Utilities::TYPE_SALE;
+				break;
+		}
+
+		if (empty($transactionJson['conversionType']) &&
+			empty($transactionJson['networkAdspaceSubid']) &&
+			$transactionJson['status'] == 'APPROVED'
+		) {
+			$transaction['action'] = Utilities::TYPE_BONUS;
+		}
+		return $transaction;
+	}
+
+
+}

--- a/Oara/Network/Publisher/WebGains.php
+++ b/Oara/Network/Publisher/WebGains.php
@@ -212,16 +212,20 @@ class WebGains extends \Oara\Network
 	        $curl_results = curl_exec($ch);
 	        curl_close($ch);
 	        $a_merchants = json_decode($curl_results, true);
-
-	        foreach ($a_merchants as $merchantJson) {
-		        $obj = Array();
-		        $obj['cid'] = $merchantJson["id"];
-		        $obj['name'] = $merchantJson["name"];
-		        $obj['status'] = $merchantJson["status"];
-		        $obj['url'] = $merchantJson["homepageURL"];
-		        $merchants[] = $obj;
-	        }
-
+            if (isset($a_merchants['code']) && $a_merchants['code'] == 401) {
+                echo "[error] Webgains Authentication Failed in get merchants";
+                return $merchants;
+            }
+            foreach ($a_merchants as $merchantJson) {
+                if (isset($merchantJson["id"])) {
+                    $obj = Array();
+                    $obj['cid'] = $merchantJson["id"];
+                    $obj['name'] = $merchantJson["name"];
+                    $obj['status'] = $merchantJson["status"];
+                    $obj['url'] = $merchantJson["homepageURL"];
+                    $merchants[] = $obj;
+                }
+            }
         }
         return $merchants;
     }

--- a/Oara/Network/Publisher/WebGains.php
+++ b/Oara/Network/Publisher/WebGains.php
@@ -46,6 +46,7 @@ class WebGains extends \Oara\Network
             return;
         }
 
+		$this->_credentials = $credentials;
         $this->_user = $credentials['user'];
         $this->_password = $credentials['password'];
         $this->_client = new \Oara\Curl\Access($credentials);
@@ -187,11 +188,14 @@ class WebGains extends \Oara\Network
 	     * https://api.webgains.com/2.0/programs
 	     */
 	    $statisticsActions = "https://api.webgains.com/2.0/programs";
+		$merchants = Array();
 	    $key = '';
-	    if (isset($_ENV['WEBGAINS_API_KEY'])){
-	    	$key = $_ENV['WEBGAINS_API_KEY'];
+	    if (isset($this->_credentials['api-key'])){
+	    	$key = $this->_credentials['api-key'];
 	    }
-	    $merchants = Array();
+		else{
+			return $merchants;
+		}
 	    foreach ($this->_campaignMap as $campaignID => $campaignValue) {
 	        $ch = curl_init();
 	        curl_setopt($ch, CURLOPT_URL, $statisticsActions . '?key=' . $key .'&campaignid='. $campaignID);

--- a/Oara/Network/Publisher/WebGains.php
+++ b/Oara/Network/Publisher/WebGains.php
@@ -34,6 +34,7 @@ class WebGains extends \Oara\Network
     private $_soapClient = null;
     private $_server = null;
     private $_campaignMap = array();
+    private $_credentials = null;
     protected $_sitesAllowed = array();
 
     /**
@@ -46,7 +47,7 @@ class WebGains extends \Oara\Network
             return;
         }
 
-		$this->_credentials = $credentials;
+        $this->_credentials = $credentials;
         $this->_user = $credentials['user'];
         $this->_password = $credentials['password'];
         $this->_client = new \Oara\Curl\Access($credentials);
@@ -188,14 +189,20 @@ class WebGains extends \Oara\Network
 	     * https://api.webgains.com/2.0/programs
 	     */
 	    $statisticsActions = "https://api.webgains.com/2.0/programs";
-		$merchants = Array();
+        $merchants = Array();
 	    $key = '';
-	    if (isset($this->_credentials['api-key'])){
-	    	$key = $this->_credentials['api-key'];
+        if (isset($this->_credentials['api-key'])) {
+            // Could pass api-key with credentials - <slawn>
+            $key = $this->_credentials['api-key'];
+        }
+	    elseif (isset($_ENV['WEBGAINS_API_KEY'])) {
+            // Fallback to environment variable
+	    	$key = $_ENV['WEBGAINS_API_KEY'];
 	    }
-		else{
-			return $merchants;
-		}
+        else {
+            // No valid key ... return empty array
+            return $merchants;
+        }
 	    foreach ($this->_campaignMap as $campaignID => $campaignValue) {
 	        $ch = curl_init();
 	        curl_setopt($ch, CURLOPT_URL, $statisticsActions . '?key=' . $key .'&campaignid='. $campaignID);

--- a/Oara/Utilities.php
+++ b/Oara/Utilities.php
@@ -52,6 +52,38 @@ class Utilities
      */
     const STATUS_PAID = 'paid';
 
+	/**
+	 * sales type sale
+	 * @var string
+	 */
+    const TYPE_SALE = 'sale';
+	/**
+	 * sales type bonus
+	 * @var string
+	 */
+    const TYPE_BONUS = 'bonus';
+	/**
+	 * sales type lead
+	 * @var string
+	 */
+    const TYPE_LEAD = 'lead';
+	/**
+	 * sales type click
+	 * @var string
+	 */
+    const TYPE_CLICK = 'click';
+	/**
+	 * sales type impression
+	 * @var string
+	 */
+    const TYPE_IMPRESSION = 'impression';
+	/**
+	 * sales type performance increase
+	 * @var string
+	 */
+    const TYPE_PERFORMANCE_INCREASE = 'performance_increase';
+
+
 
     /**
      * offer type Voucher


### PR DESCRIPTION
Affiliate Window
- fixing transactions as it is currently braking compatibility with rest of library - it was returning Affiliate Window object instead of usual transaction array
- moved timezone form method parameter into settings
- change the end date for the API call as it should contain the last day - so time should be 23:59:59 as it was previously and to keep consistent with rest of the library

LinkShare
Adding option to group the commissions by order instead of grouping by items. This doesn't change the default functionality, but rather adds additional option that can be passed in the settings and then the transactions will be grouped by order id.